### PR TITLE
Glm/fragment aggregator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(coredal REQUIRED)
 
 #find_package(Boost COMPONENTS unit_test_framework REQUIRED)
 
+include_directories(${CMAKE_BINARY_DIR}/coredal ${CMAKE_BINARY_DIR}/appdal)
 
 daq_oks_codegen(readout.schema.xml NAMESPACE dunedaq::appdal DEP_PKGS coredal)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,8 +18,9 @@ know how to connect the modules internally and to network endpoints.
 
 *NB:* The declaration of the `generate_modules()` method must be
  repeated in each subclass and an implementation provided. The
- declaration in **SmartDaqApplication** is not pur virtual but its
- implemetation just throws a 'not implemented' exception.
+ declaration in **SmartDaqApplication** is not pure virtual but its
+ implemetation calls the generate_modules() implementation of the
+ specific subclass using a 'magic' map of class names to generate functions.
 
 ## ReadoutApplication
 
@@ -32,7 +33,7 @@ can contain any class inheriting from **RsourceBase** but should only
 contain **ReadoutGroups**. The `generate_modules()` method will
 generate a **DataReader** and set of **DataLinkHandlers** for each
 **ReadoutGroup** plus a single **TPHandler**. The modules are created
-accoriding to the configuration given by the data_reader, link_handler
+according to the configuration given by the data_reader, link_handler
 and tp_handler relationships respectively. Connections between pairs
 of modules are configured according to the queue_rules relationship
 inherited from **SmartDaqApplication**.

--- a/schema/appdal/readout.schema.xml
+++ b/schema/appdal/readout.schema.xml
@@ -222,6 +222,10 @@
   <attribute name="host" type="string" init-value="localhost" is-not-null="yes"/>
  </class>
 
+ <class name="FragmentAggregator">
+  <superclass name="DaqModule"/>
+ </class>
+
  <class name="HDF5FileLayoutParams">
   <attribute name="record_name_prefix" type="string" init-value="TriggerRecord" is-not-null="yes"/>
   <attribute name="digits_for_record_number" type="s32" init-value="6"/>
@@ -295,11 +299,9 @@
 
  <class name="NetworkConnectionDescriptor">
   <attribute name="uid_base" description="Base for UID string. To be combined with a source id" type="string" is-not-null="yes"/>
-  <attribute name="data_type" type="string" is-not-null="yes"/>
   <attribute name="connection_type" type="enum" range="kSendRecv,kPubSub" init-value="kSendRecv" is-not-null="yes"/>
-  <attribute name="port" type="u16" init-value="0"/>
-  <attribute name="uri" type="string" init-value="tcp://0.0.0.0:*" is-not-null="yes"/>
- </class>
+  <relationship name="associated_service" description="Service provided by this connection" class-type="Service" low-cc="one" high-cc="one" is-composite="yes" is-exclusive="no" is-dependent="yes"/>
+</class>
 
  <class name="NetworkConnectionRule">
   <attribute name="endpoint_class" type="class" init-value="DaqModule"/>

--- a/src/ReadoutApplication.cpp
+++ b/src/ReadoutApplication.cpp
@@ -114,6 +114,9 @@ ReadoutApplication::generate_modules(oksdbinterfaces::Configuration* confdb,
 
   // Create here the Queue on which all data fragments are forwarded to the fragment aggregator
   // and a container for the queues of data request to TP handler and DLH
+  if (faOutputQDesc == nullptr) {
+    throw (BadConf(ERS_HERE, "No fragment output queue descriptor given"));
+  }
   oksdbinterfaces::ConfigObject faQueueObj;
   std::vector<const coredal::Connection*> faOutputQueues;
 
@@ -139,9 +142,6 @@ ReadoutApplication::generate_modules(oksdbinterfaces::Configuration* confdb,
     }
     if (tpReqInputQDesc == nullptr) {
       throw (BadConf(ERS_HERE, "No tpHandler data request queue descriptor given"));
-    }
-    if (faOutputQDesc == nullptr) {
-      throw (BadConf(ERS_HERE, "No tpHandler fragment output queue descriptor given"));
     }
     if (tsNetDesc == nullptr) {
       throw (BadConf(ERS_HERE, "No timesync output network descriptor given"));
@@ -187,6 +187,12 @@ ReadoutApplication::generate_modules(oksdbinterfaces::Configuration* confdb,
   auto rdrConf = get_data_reader();
   if (rdrConf == 0) {
     throw (BadConf(ERS_HERE, "No DataReader configuration given"));
+  }
+  if (dlhInputQDesc == nullptr) {
+    throw (BadConf(ERS_HERE, "No DLH data input queue descriptor given"));
+  }
+  if (dlhReqInputQDesc == nullptr) {
+    throw (BadConf(ERS_HERE, "No DLH request input queue descriptor given"));
   }
 
   int rnum = 0;


### PR DESCRIPTION
This PR introduces the Fragment Aggregator for the readout application.
It also makes use of the modified NetworkConnection class in the coredal (feature/service_exposure branch) schema.
More testing is needed on the connectivity establishment in the generate_modules code, but at least things compile and seem correct at first sight.