### PR TITLE
Enabling the TC-making application & increasing prescale

### DIFF
--- a/test/boot.json
+++ b/test/boot.json
@@ -15,10 +15,15 @@
       "host": "local",
       "port": 3339
     },
-    "mlt": {
+    "tc-maker-1": {
       "exec": "daq_application_ssh",
       "host": "local",
       "port": 3352
+    },
+    "mlt": {
+      "exec": "daq_application_ssh",
+      "host": "local",
+      "port": 3355
     }
   },
   "env": {
@@ -69,7 +74,6 @@
         "INFO_SVC": "file://info_{APP_NAME}_{APP_PORT}.json",
         "LD_LIBRARY_PATH": "getenv",
         "PATH": "getenv",
-        "TIMING_SHARE": "getenv",
         "TRACE_FILE": "getenv:/tmp/trace_buffer_{APP_HOST}_{DUNEDAQ_PARTITION}"
       }
     }

--- a/test/config/trigger-segment.data.xml
+++ b/test/config/trigger-segment.data.xml
@@ -167,6 +167,7 @@
 <obj class="Segment" id="trg-segment">
  <rel name="applications">
   <ref class="MLTApplication" id="mlt"/>
+  <ref class="TriggerApplication" id="tc-maker-1"/>
  </rel>
  <rel name="controller" class="RCApplication" id="trg-controller"/>
 </obj>
@@ -214,7 +215,7 @@
 </obj>
 
 <obj class="TriggerCandidateMakerPrescalePlugin" id="tc-pass-through-algo">
- <attr name="prescale" type="u32" val="2"/>
+ <attr name="prescale" type="u32" val="20"/>
 </obj>
 
 </oks-data>


### PR DESCRIPTION
To merge after https://github.com/DUNE-DAQ/trigger/pull/280 is merged.

* Enabled tc-making application, since the PR above makes it work.
* Increased TC-making prescale, I was getting a bit high rates with TC prescale of 2.
* Removed the `"TIMING_SHARE": "getenv",` line from `boot.json`, it makes nanorc crash...