### PR TITLE
Asztuc/adding tcbuffering

### DIFF
--- a/config/appdal/connections.data.xml
+++ b/config/appdal/connections.data.xml
@@ -125,6 +125,13 @@
  <rel name="associated_service" class="Service" id="triggerCandidates"/>
 </obj>
 
+<obj class="NetworkConnectionDescriptor" id="tc-mlt-desc">
+ <attr name="uid_base" type="string" val="tcs_mlt_"/>
+ <attr name="connection_type" type="enum" val="kPubSub"/>
+ <attr name="data_type" type="string" val="TriggerCandidate"/>
+ <rel name="associated_service" class="Service" id="triggerCandidates"/>
+</obj>
+
 <obj class="NetworkConnectionDescriptor" id="timesync-publisher">
  <attr name="uid_base" type="string" val="time_sync_"/>
  <attr name="connection_type" type="enum" val="kPubSub"/>
@@ -202,6 +209,11 @@
 
 <obj class="NetworkConnectionRule" id="tc-mlt-rule">
  <attr name="endpoint_class" type="class" val="ModuleLevelTrigger"/>
+ <rel name="descriptor" class="NetworkConnectionDescriptor" id="tc-mlt-desc"/>
+</obj>
+
+<obj class="NetworkConnectionRule" id="tc-net-rule">
+ <attr name="endpoint_class" type="class" val="DataSubscriber"/>
  <rel name="descriptor" class="NetworkConnectionDescriptor" id="tc-desc"/>
 </obj>
 
@@ -255,6 +267,11 @@
  <rel name="descriptor" class="QueueDescriptor" id="ta-input"/>
 </obj>
 
+ <obj class="QueueConnectionRule" id="tc-queue-rule">
+ <attr name="destination_class" type="class" val="TriggerDataHandler"/>
+ <rel name="descriptor" class="QueueDescriptor" id="tc-input"/>
+</obj>
+
 <obj class="QueueConnectionRule" id="tp-queue-rule">
  <attr name="destination_class" type="class" val="TriggerDataHandler"/>
  <rel name="descriptor" class="QueueDescriptor" id="tp-input"/>
@@ -303,6 +320,13 @@
  <attr name="queue_type" type="enum" val="kFollySPSCQueue"/>
  <attr name="capacity" type="u32" val="1000"/>
  <attr name="data_type" type="string" val="TriggerActivity"/>
+</obj>
+
+<obj class="QueueDescriptor" id="tc-input">
+ <attr name="uid_base" type="string" val="tc_input_"/>
+ <attr name="queue_type" type="enum" val="kFollySPSCQueue"/>
+ <attr name="capacity" type="u32" val="1000"/>
+ <attr name="data_type" type="string" val="TriggerCandidate"/>
 </obj>
 
 <obj class="QueueDescriptor" id="tp-input">

--- a/src/TriggerApplication.cpp
+++ b/src/TriggerApplication.cpp
@@ -114,13 +114,34 @@ TriggerApplication::generate_modules(oksdbinterfaces::Configuration* confdb,
       req_net_desc = rule->get_descriptor();
     }
     else if (data_type == "TASet" || data_type == "TCSet"){
-	tset_out_net_desc = rule->get_descriptor();
+      tset_out_net_desc = rule->get_descriptor();
     }
     else if (endpoint_class == "DataSubscriber") {
+      if (!tin_net_desc) {
         tin_net_desc =  rule->get_descriptor();
+      }
+      else if (rule->get_descriptor()->get_data_type() == tin_net_desc->get_data_type()) {
+        // For now endpoint_class of DataSubscriber for both input and output
+        // with the same data type is not possible.
+        throw (BadConf(ERS_HERE, "Have two network connections of the same data_type and the same endpoint_class"));
+      }
+      else if (tin_net_desc->get_data_type() == "TriggerActivity" &&
+          rule->get_descriptor()->get_data_type() == "TriggerCandidate") {
+        // For TA->TC
+        tout_net_desc = rule->get_descriptor();
+      }
+      else if (tin_net_desc->get_data_type() == "TriggerCandidate" &&
+          rule->get_descriptor()->get_data_type() == "TriggerActivity") {
+        // For TA->TC if we saved TC network connection as input first...
+        tout_net_desc = tin_net_desc;
+        tin_net_desc = rule->get_descriptor();
+      }
+      else {
+        throw (BadConf(ERS_HERE, "Unexpected input & output network connection descriptors provided"));
+      }
     }
     else if (data_type == "TriggerActivity" || data_type == "TriggerCandidate"){
-	tout_net_desc = rule->get_descriptor();
+      tout_net_desc = rule->get_descriptor();
     }
   }
 

--- a/test/boot.json
+++ b/test/boot.json
@@ -20,10 +20,15 @@
       "host": "local",
       "port": 3352
     },
-    "mlt": {
+    "tc-buffer-1": {
       "exec": "daq_application_ssh",
       "host": "local",
       "port": 3355
+    },
+    "mlt": {
+      "exec": "daq_application_ssh",
+      "host": "local",
+      "port": 3358
     }
   },
   "env": {

--- a/test/config/trigger-segment.data.xml
+++ b/test/config/trigger-segment.data.xml
@@ -106,11 +106,16 @@
  <attr name="emulation_mode" type="bool" val="0"/>
 </obj>
 
+<obj class="DataReaderConf" id="tc-subscriber-1">
+ <attr name="template_for" type="class" val="DataSubscriber"/>
+ <attr name="emulation_mode" type="bool" val="0"/>
+</obj>
+
 <obj class="MLTApplication" id="mlt">
  <attr name="application_name" type="string" val="daq_application"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="network_rules">
-  <ref class="NetworkConnectionRule" id="tc-mlt-rule"/>
+  <ref class="NetworkConnectionRule" id="tc-net-rule"/>
   <ref class="NetworkConnectionRule" id="ti-net-rule"/>
   <ref class="NetworkConnectionRule" id="td-dfo-net-rule"/>
  </rel>
@@ -158,7 +163,25 @@
  <rel name="data_processor" class="TADataProcessor" id="def-ta-processor"/>
 </obj>
 
+<obj class="ReadoutModuleConf" id="dummy-tc-handler">
+ <attr name="template_for" type="class" val="TriggerDataHandler"/>
+ <attr name="input_data_type" type="string" val="TriggerCandidate"/>
+ <attr name="generate_timesync" type="bool" val="0"/>
+ <rel name="request_handler" class="RequestHandler" id="def-tc-request-handler"/>
+ <rel name="latency_buffer" class="LatencyBuffer" id="def-latency-buf"/>
+ <rel name="data_processor" class="DataProcessor" id="dummy-tc-processor"/>
+</obj>
+
 <obj class="RequestHandler" id="def-ta-request-handler">
+ <attr name="handler_threads" type="u16" val="1"/>
+ <attr name="request_timeout" type="u32" val="10000"/>
+ <attr name="pop_limit_pct" type="float" val="0.5"/>
+ <attr name="pop_size_pct" type="float" val="0.8"/>
+ <attr name="warn_on_timeout" type="bool" val="1"/>
+ <attr name="warn_on_empty_buffer" type="bool" val="1"/>
+</obj>
+
+<obj class="RequestHandler" id="def-tc-request-handler">
  <attr name="handler_threads" type="u16" val="1"/>
  <attr name="request_timeout" type="u32" val="10000"/>
  <attr name="pop_limit_pct" type="float" val="0.5"/>
@@ -171,6 +194,7 @@
  <rel name="applications">
   <ref class="MLTApplication" id="mlt"/>
   <ref class="TriggerApplication" id="tc-maker-1"/>
+  <ref class="TriggerApplication" id="tc-buffer-1"/>
  </rel>
  <rel name="controller" class="RCApplication" id="trg-controller"/>
 </obj>
@@ -183,6 +207,12 @@
  <rel name="algorithms">
   <ref class="TriggerCandidateMakerPrescalePlugin" id="tc-pass-through-algo"/>
  </rel>
+</obj>
+
+<obj class="DataProcessor" id="dummy-tc-processor">
+ <attr name="queue_sizes" type="u32" val="10000"/>
+ <attr name="thread_names_prefix" type="string" val="proc-"/>
+ <attr name="mask_processing" type="bool" val="0"/>
 </obj>
 
 <obj class="TimingTriggerOffsetMap" id="ttcm-off-0">
@@ -204,23 +234,7 @@
   
 <obj class="TCReadoutMap" id="def-tc-map">
  <attr name="time_before" type="u32" val="3000"/>
- <attr name="time_after" type="u32" val="1001"/>
-</obj>
-
-<obj class="TriggerApplication" id="ta-maker-1">
- <attr name="source_id" type="u32" val="100"/>
- <attr name="application_name" type="string" val="daq_application"/>
- <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
- <rel name="queue_rules">
-  <ref class="QueueConnectionRule" id="tp-queue-rule"/>
- </rel>
- <rel name="network_rules">
-  <ref class="NetworkConnectionRule" id="ta-net-rule"/>
-  <ref class="NetworkConnectionRule" id="tp-net-rule"/>
-  <ref class="NetworkConnectionRule" id="data-req-trig-net-rule"/>
- </rel>
- <rel name="data_subscriber" class="DataReaderConf" id="ta-subscriber-1"/>
- <rel name="trigger_inputs_handler" class="ReadoutModuleConf" id="trg-tp-handler"/>
+ <attr name="time_after" type="u32" val="1000"/>
 </obj>
 
 <obj class="TriggerApplication" id="tc-maker-1">
@@ -232,11 +246,27 @@
  </rel>
  <rel name="network_rules">
   <ref class="NetworkConnectionRule" id="ta-net-rule"/>
+  <ref class="NetworkConnectionRule" id="tc-net-rule"/>
+  <ref class="NetworkConnectionRule" id="data-req-trig-net-rule"/>
+ </rel>
+ <rel name="data_subscriber" class="DataReaderConf" id="tc-subscriber-1"/>
+ <rel name="trigger_inputs_handler" class="ReadoutModuleConf" id="def-ta-handler"/>
+</obj>
+
+<obj class="TriggerApplication" id="tc-buffer-1">
+ <attr name="source_id" type="u32" val="11000"/>
+ <attr name="application_name" type="string" val="daq_application"/>
+ <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
+ <rel name="queue_rules">
+  <ref class="QueueConnectionRule" id="tc-queue-rule"/>
+ </rel>
+ <rel name="network_rules">
+  <ref class="NetworkConnectionRule" id="tc-net-rule"/>
   <ref class="NetworkConnectionRule" id="tc-mlt-rule"/>
   <ref class="NetworkConnectionRule" id="data-req-trig-net-rule"/>
  </rel>
- <rel name="data_subscriber" class="DataReaderConf" id="ta-subscriber-1"/>
- <rel name="trigger_inputs_handler" class="ReadoutModuleConf" id="def-ta-handler"/>
+ <rel name="data_subscriber" class="DataReaderConf" id="tc-subscriber-1"/>
+ <rel name="trigger_inputs_handler" class="ReadoutModuleConf" id="dummy-tc-handler"/>
 </obj>
 
 <obj class="TriggerCandidateMakerPrescalePlugin" id="tc-pass-through-algo">


### PR DESCRIPTION
Adding TC buffering. It works, and TC fragments from the trigger's latency buffers are successfully saved in the hdf5 files!
I had to make few small changes to accomodate for that, and a small re-write of how MLT sits in OKS might be needed in the future. Issues:

* TC maker module subscribes to network publishing TriggerActivities, with `endpoint_class` of `DataSubscriber`. For buffering, it needs to publish `TriggerCandidates` with `endpoint_class` of `DataSubscriber`, and by default `DataSubscriber` endpoint was treated as inputs-only in `TriggerApplication.cpp`.
* TC buffer module needs input connection (for TCs to go in), and output network connection (seems to be enforced by `ReadoutModule` structure, even if the module is not actually publishing anything).
* With both of these in mind, I have two network connections for TCs. One with `endpoint_class` of `DataSubscriber` -- that's what's effectively being used everywhere, and one with `endpoint_class` of `ModuleLevelTrigger` -- a dummy, the buffering module needs output network to work, despite not publishing anything.

I think long-term the TC buffering should be moved to the module handling MLT, which means moving MLT to the ReadoutModule-like structure too. I think this would make sense, and will probably try to work on this next.

I hope someone has better/simpler ideas from what I've done for this PR though...