### PR TITLE
DAQ App CLI env vars

### DIFF
--- a/test/config/df-segment.data.xml
+++ b/test/config/df-segment.data.xml
@@ -95,9 +95,9 @@
   <data val="-c"/>
   <data val="rest://localhost:3339"/><!-- ALTER_ME -->
   <data val="-i"/>
-  <data val="kafka://monkafka.cern.ch:30092/opmon"/>
+  <data val="${DAQAPP_CLI_INFO_SVC}"/>
   <data val="--configurationService"/>
-  <data val="oksconfig:test/config/test-session.data.xml"/><!-- ALTER_ME -->
+  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
  </attr>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="source_id" class="SourceIDConf" id="srcid-df-01"/>
@@ -124,9 +124,9 @@
   <data val="-c"/>
   <data val="rest://localhost:3340"/><!-- ALTER_ME -->
   <data val="-i"/>
-  <data val="kafka://monkafka.cern.ch:30092/opmon"/>
+  <data val="${DAQAPP_CLI_INFO_SVC}"/>
   <data val="--configurationService"/>
-  <data val="oksconfig:test/config/test-session.data.xml"/><!-- ALTER_ME -->
+  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
  </attr>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="source_id" class="SourceIDConf" id="srcid-df-02"/>
@@ -152,9 +152,9 @@
   <data val="-c"/>
   <data val="rest://np04-srv-019:3341"/><!-- ALTER_ME -->
   <data val="-i"/>
-  <data val="kafka://monkafka.cern.ch:30092/opmon"/>
+  <data val="${DAQAPP_CLI_INFO_SVC}"/>
   <data val="--configurationService"/>
-  <data val="oksconfig:test/config/test-session.data.xml"/><!-- ALTER_ME -->
+  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
  </attr>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="source_id" class="SourceIDConf" id="srcid-df-03"/>
@@ -186,9 +186,9 @@
   <data val="-c"/>
   <data val="rest://np04-srv-019:3342"/><!-- ALTER_ME -->
   <data val="-i"/>
-  <data val="kafka://monkafka.cern.ch:30092/opmon"/>
+  <data val="${DAQAPP_CLI_INFO_SVC}"/>
   <data val="--configurationService"/>
-  <data val="oksconfig:test/config/test-session.data.xml"/><!-- ALTER_ME -->
+  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
  </attr>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="network_rules">
@@ -234,7 +234,7 @@
 <obj class="RCApplication" id="df-controller">
  <attr name="application_name" type="string" val="drunc-controller"/>
  <attr name="commandline_parameters" type="string">
-  <data val="oksconfig://test/config/test-session.data.xml"/><!-- ALTER_ME -->
+  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
   <data val="grpc://np04-srv-019:3338"/><!-- ALTER_ME -->
   <data val="df-segment"/>
   <data val="test-session"/>
@@ -253,9 +253,9 @@
   <data val="-c"/>
   <data val="rest://np04-srv-019:3343"/><!-- ALTER_ME -->
   <data val="-i"/>
-  <data val="kafka://monkafka.cern.ch:30092/opmon"/>
+  <data val="${DAQAPP_CLI_INFO_SVC}"/>
   <data val="--configurationService"/>
-  <data val="oksconfig:test/config/test-session.data.xml"/><!-- ALTER_ME -->
+  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
  </attr>
   <rel name="source_id" class="SourceIDConf" id="srcid-tp-stream-writer"/>
  <rel name="network_rules">

--- a/test/config/df-segment.data.xml
+++ b/test/config/df-segment.data.xml
@@ -150,7 +150,7 @@
   <data val="--name"/>
   <data val="df-03"/>
   <data val="-c"/>
-  <data val="rest://np04-srv-019:3341"/><!-- ALTER_ME -->
+  <data val="rest://localhost:3341"/><!-- ALTER_ME -->
   <data val="-i"/>
   <data val="${DAQAPP_CLI_INFO_SVC}"/>
   <data val="--configurationService"/>
@@ -184,7 +184,7 @@
   <data val="--name"/>
   <data val="dfo-01"/>
   <data val="-c"/>
-  <data val="rest://np04-srv-019:3342"/><!-- ALTER_ME -->
+  <data val="rest://localhost:3342"/><!-- ALTER_ME -->
   <data val="-i"/>
   <data val="${DAQAPP_CLI_INFO_SVC}"/>
   <data val="--configurationService"/>
@@ -235,7 +235,7 @@
  <attr name="application_name" type="string" val="drunc-controller"/>
  <attr name="commandline_parameters" type="string">
   <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
-  <data val="grpc://np04-srv-019:3338"/><!-- ALTER_ME -->
+  <data val="grpc://localhost:3338"/><!-- ALTER_ME -->
   <data val="df-segment"/>
   <data val="test-session"/>
  </attr>
@@ -251,7 +251,7 @@
   <data val="--name"/>
   <data val="tp-stream-writer"/>
   <data val="-c"/>
-  <data val="rest://np04-srv-019:3343"/><!-- ALTER_ME -->
+  <data val="rest://localhost:3343"/><!-- ALTER_ME -->
   <data val="-i"/>
   <data val="${DAQAPP_CLI_INFO_SVC}"/>
   <data val="--configurationService"/>

--- a/test/config/hsi-segment.data.xml
+++ b/test/config/hsi-segment.data.xml
@@ -90,7 +90,7 @@
   <data val="--name"/>
   <data val="hsi-01"/>
   <data val="-c"/>
-  <data val="rest://np04-srv-019:3382"/><!-- ALTER_ME -->
+  <data val="rest://localhost:3382"/><!-- ALTER_ME -->
   <data val="-i"/>
   <data val="${DAQAPP_CLI_INFO_SVC}"/>
   <data val="--configurationService"/>
@@ -135,7 +135,7 @@
  <rel name="fsm" class="FSMconfiguration" id="fsmConf-1"/>
  <attr name="commandline_parameters" type="string">
   <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
-  <data val="grpc://np04-srv-019:3498"/><!-- ALTER_ME -->
+  <data val="grpc://localhost:3498"/><!-- ALTER_ME -->
   <data val="hsi-segment"/>
   <data val="test-session"/>
  </attr>

--- a/test/config/hsi-segment.data.xml
+++ b/test/config/hsi-segment.data.xml
@@ -86,6 +86,16 @@
  <attr name="application_name" type="string" val="daq_application"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="source_id" class="SourceIDConf" id="hsi-srcid-01"/>
+ <attr name="commandline_parameters" type="string">
+  <data val="--name"/>
+  <data val="hsi-01"/>
+  <data val="-c"/>
+  <data val="rest://np04-srv-019:3382"/><!-- ALTER_ME -->
+  <data val="-i"/>
+  <data val="${DAQAPP_CLI_INFO_SVC}"/>
+  <data val="--configurationService"/>
+  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
+ </attr>
  <rel name="queue_rules">
   <ref class="QueueConnectionRule" id="hsi-raw-data-rule"/>
  </rel>
@@ -120,9 +130,16 @@
 </obj>
 
 <obj class="RCApplication" id="hsi-controller">
- <attr name="application_name" type="string" val="controller"/>
+ <attr name="application_name" type="string" val="drunc-controller"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="fsm" class="FSMconfiguration" id="fsmConf-1"/>
+ <attr name="commandline_parameters" type="string">
+  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
+  <data val="grpc://np04-srv-019:3498"/><!-- ALTER_ME -->
+  <data val="hsi-segment"/>
+  <data val="test-session"/>
+ </attr>
+ <rel name="broadcaster" class="RCBroadcaster" id="broadcaster-root"/>
 </obj>
 
 <obj class="ReadoutModuleConf" id="def-hsi-handler">

--- a/test/config/ru-segment.data.xml
+++ b/test/config/ru-segment.data.xml
@@ -97,7 +97,7 @@
  <attr name="application_name" type="string" val="drunc-controller"/>
  <attr name="commandline_parameters" type="string">
   <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
-  <data val="grpc://np04-srv-019:3334"/><!-- ALTER_ME -->
+  <data val="grpc://localhost:3334"/><!-- ALTER_ME -->
   <data val="ru-segment"/>
   <data val="test-session"/>
  </attr>

--- a/test/config/ru-segment.data.xml
+++ b/test/config/ru-segment.data.xml
@@ -96,7 +96,7 @@
 <obj class="RCApplication" id="ru-controller">
  <attr name="application_name" type="string" val="drunc-controller"/>
  <attr name="commandline_parameters" type="string">
-  <data val="oksconfig://test/config/test-session.data.xml"/><!-- ALTER_ME -->
+  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
   <data val="grpc://np04-srv-019:3334"/><!-- ALTER_ME -->
   <data val="ru-segment"/>
   <data val="test-session"/>
@@ -114,11 +114,11 @@
   <data val="--name"/>
   <data val="ru-01"/>
   <data val="-c"/>
-  <data val="rest://localhost:3335"/><!-- ALTER_ME -->
+  <data val="rest://localhost:4335"/><!-- ALTER_ME -->
   <data val="-i"/>
-  <data val="kafka://monkafka.cern.ch:30092/opmon"/>
+  <data val="${DAQAPP_CLI_INFO_SVC}"/>
   <data val="--configurationService"/>
-  <data val="oksconfig:test/config/test-session.data.xml"/><!-- ALTER_ME -->
+  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
  </attr>
  <rel name="contains">
   <ref class="ReadoutGroup" id="rog-1"/>
@@ -156,11 +156,11 @@
   <data val="--name"/>
   <data val="ru-02"/>
   <data val="-c"/>
-  <data val="rest://localhost:3335"/><!-- ALTER_ME -->
+  <data val="rest://localhost:4336"/><!-- ALTER_ME -->
   <data val="-i"/>
-  <data val="kafka://monkafka.cern.ch:30092/opmon"/>
+  <data val="${DAQAPP_CLI_INFO_SVC}"/>
   <data val="--configurationService"/>
-  <data val="oksconfig:test/config/test-session.data.xml"/><!-- ALTER_ME -->
+  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
  </attr>
  <rel name="contains">
   <ref class="ReadoutGroup" id="rog-2"/>
@@ -192,11 +192,11 @@
   <data val="--name"/>
   <data val="ru-03"/>
   <data val="-c"/>
-  <data val="rest://localhost:3335"/><!-- ALTER_ME -->
+  <data val="rest://localhost:4337"/><!-- ALTER_ME -->
   <data val="-i"/>
-  <data val="kafka://monkafka.cern.ch:30092/opmon"/>
+  <data val="${DAQAPP_CLI_INFO_SVC}"/>
   <data val="--configurationService"/>
-  <data val="oksconfig:test/config/test-session.data.xml"/><!-- ALTER_ME -->
+  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
 
  </attr>
  <rel name="contains">

--- a/test/config/test-session.data.xml
+++ b/test/config/test-session.data.xml
@@ -122,7 +122,7 @@
  <attr name="connectivity_service_interval_ms" type="u32" val="2000"/>
  <attr name="data_request_timeout_ms" type="u32" val="1000"/>
  <attr name="data_rate_slowdown_factor" type="u32" val="1"/>
- <attr name="rte_script" type="string" val="/nfs/home/plasorak/NFD_DEV_240320_A9/swdir/install/daq_app_rte.sh"><!-- ALTER_ME -->
+ <attr name="rte_script" type="string" val="/point/to/your/install/daq_app_rte.sh"><!-- ALTER_ME -->
  <rel name="environment">
   <ref class="Variable" id="session-env-session-name-0"/>
   <ref class="Variable" id="session-env-session-name-1"/>

--- a/test/config/test-session.data.xml
+++ b/test/config/test-session.data.xml
@@ -95,7 +95,7 @@
 
 <obj class="RCApplication" id="root-controller">
  <attr name="commandline_parameters" type="string">
-  <data val="oksconfig://test/config/test-session.data.xml"/><!-- ALTER_ME -->
+  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
   <data val="grpc://np04-srv-019:3333"/><!-- ALTER_ME -->
   <data val="root-segment"/>
   <data val="test-session"/>
@@ -122,11 +122,10 @@
  <attr name="connectivity_service_interval_ms" type="u32" val="2000"/>
  <attr name="data_request_timeout_ms" type="u32" val="1000"/>
  <attr name="data_rate_slowdown_factor" type="u32" val="1"/>
- <attr name="rte_script" type="string" val="/nfs/home/plasorak/NAFD24-02-08-OKS/swdir/install/daq_app_rte.sh"><!-- ALTER_ME -->
+ <attr name="rte_script" type="string" val="/nfs/home/plasorak/NFD_DEV_240320_A9/swdir/install/daq_app_rte.sh"><!-- ALTER_ME -->
  <rel name="environment">
   <ref class="Variable" id="session-env-session-name-0"/>
   <ref class="Variable" id="session-env-session-name-1"/>
-  <ref class="Variable" id="session-env-info-svc"/>
   <ref class="Variable" id="session-env-ers-verb"/>
   <ref class="Variable" id="session-env-ers-info"/>
   <ref class="Variable" id="session-env-ers-warning"/>
@@ -134,6 +133,8 @@
   <ref class="Variable" id="session-env-ers-fatal"/>
   <ref class="Variable" id="session-env-connectivity-server"/>
   <ref class="Variable" id="session-env-connectivity-port"/>
+  <ref class="Variable" id="daqapp-cli-monitoring"/>
+  <ref class="Variable" id="daqapp-cli-configuration"/>
  </rel>
  <rel name="disabled">
   <ref class="ReadoutGroup" id="rog-3"/>
@@ -144,6 +145,8 @@
  <rel name="readout_map" class="ReadoutMap" id="dummyRoMap"/>
 </obj>
 
+
+<!-- SESSION NAME -->
 <obj class="Variable" id="session-env-session-name-0">
  <attr name="name" type="string" val="DUNEDAQ_PARTITION"/>
  <attr name="value" type="string" val="test-session"/>
@@ -154,16 +157,12 @@
  <attr name="value" type="string" val="test-session"/>
 </obj>
 
+
+<!-- ERS CONF -->
 <obj class="Variable" id="session-env-ers-verb">
  <attr name="name" type="string" val="DUNEDAQ_ERS_VERBOSITY_LEVEL"/>
  <attr name="value" type="string" val="1"/>
 </obj>
-
-<obj class="Variable" id="session-env-info-svc">
- <attr name="name" type="string" val="INFO_SVC"/>
- <attr name="value" type="string" val="kafka://monkafka.cern.ch:30092/opmon"/>
-</obj>
-
 
 <obj class="Variable" id="session-env-ers-info">
  <attr name="name" type="string" val="DUNEDAQ_ERS_INFO"/>
@@ -186,7 +185,7 @@
 </obj>
 
 
-
+<!-- CONNECTIVITY SVC -->
 <obj class="Variable" id="session-env-connectivity-server">
  <attr name="name" type="string" val="CONNECTION_SERVER"/>
  <attr name="value" type="string" val="np04-srv-017"/>
@@ -195,6 +194,18 @@
 <obj class="Variable" id="session-env-connectivity-port">
  <attr name="name" type="string" val="CONNECTION_PORT"/>
  <attr name="value" type="string" val="30005"/>
+</obj>
+
+
+<!-- DAQ APP CLI -->
+<obj class="Variable" id="daqapp-cli-monitoring">
+ <attr name="name" type="string" val="DAQAPP_CLI_INFO_SVC"/>
+ <attr name="value" type="string" val="kafka://monkafka.cern.ch:30092/opmon"/>
+</obj>
+
+<obj class="Variable" id="daqapp-cli-configuration">
+ <attr name="name" type="string" val="DAQAPP_CLI_CONFIG_SVC"/>
+ <attr name="value" type="string" val="oksconfig:test/config/test-session.data.xml"/>
 </obj>
 
 </oks-data>

--- a/test/config/test-session.data.xml
+++ b/test/config/test-session.data.xml
@@ -96,7 +96,7 @@
 <obj class="RCApplication" id="root-controller">
  <attr name="commandline_parameters" type="string">
   <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
-  <data val="grpc://np04-srv-019:3333"/><!-- ALTER_ME -->
+  <data val="grpc://localhost:3333"/><!-- ALTER_ME -->
   <data val="root-segment"/>
   <data val="test-session"/>
  </attr>

--- a/test/config/trigger-segment.data.xml
+++ b/test/config/trigger-segment.data.xml
@@ -132,6 +132,16 @@
  <attr name="application_name" type="string" val="daq_application"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="source_id" class="SourceIDConf" id="hsi-tc-srcid-1"/>
+ <attr name="commandline_parameters" type="string">
+  <data val="--name"/>
+  <data val="hsi-to-tc-app"/>
+  <data val="-c"/>
+  <data val="rest://localhost:3348"/><!-- ALTER_ME -->
+  <data val="-i"/>
+  <data val="${DAQAPP_CLI_INFO_SVC}"/>
+  <data val="--configurationService"/>
+  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
+ </attr>
  <rel name="network_rules">
   <ref class="NetworkConnectionRule" id="hsi-rule"/>
   <ref class="NetworkConnectionRule" id="tc-mlt-rule"/>
@@ -151,13 +161,13 @@
  <rel name="source_id" class="SourceIDConf" id="mlt-srcid-01"/>
  <attr name="commandline_parameters" type="string">
   <data val="--name"/>
-  <data val="tc-maker-1"/>
+  <data val="mlt"/>
   <data val="-c"/>
   <data val="rest://localhost:3346"/><!-- ALTER_ME -->
   <data val="-i"/>
-  <data val="kafka://monkafka.cern.ch:30092/opmon"/>
+  <data val="${DAQAPP_CLI_INFO_SVC}"/>
   <data val="--configurationService"/>
-  <data val="oksconfig:test/config/test-session.data.xml"/><!-- ALTER_ME -->
+  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
  </attr>
  <rel name="network_rules">
   <ref class="NetworkConnectionRule" id="tc-net-rule"/>
@@ -189,7 +199,7 @@
 <obj class="RCApplication" id="trg-controller">
  <attr name="application_name" type="string" val="drunc-controller"/>
  <attr name="commandline_parameters" type="string">
-  <data val="oksconfig://test/config/test-session.data.xml"/><!-- ALTER_ME -->
+  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
   <data val="grpc://np04-srv-019:3335"/><!-- ALTER_ME -->
   <data val="trg-segment"/>
   <data val="test-session"/>
@@ -315,13 +325,13 @@
  <attr name="application_name" type="string" val="daq_application"/>
  <attr name="commandline_parameters" type="string">
   <data val="--name"/>
-  <data val="ta-01"/>
+  <data val="tc-buffer-1"/>
   <data val="-c"/>
   <data val="rest://localhost:3344"/><!-- ALTER_ME -->
   <data val="-i"/>
-  <data val="kafka://monkafka.cern.ch:30092/opmon"/>
+  <data val="${DAQAPP_CLI_INFO_SVC}"/>
   <data val="--configurationService"/>
-  <data val="oksconfig:test/config/test-session.data.xml"/><!-- ALTER_ME -->
+  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
  </attr>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
@@ -349,9 +359,9 @@
   <data val="-c"/>
   <data val="rest://localhost:3345"/><!-- ALTER_ME -->
   <data val="-i"/>
-  <data val="kafka://monkafka.cern.ch:30092/opmon"/>
+  <data val="${DAQAPP_CLI_INFO_SVC}"/>
   <data val="--configurationService"/>
-  <data val="oksconfig:test/config/test-session.data.xml"/><!-- ALTER_ME -->
+  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
  </attr>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">

--- a/test/config/trigger-segment.data.xml
+++ b/test/config/trigger-segment.data.xml
@@ -200,7 +200,7 @@
  <attr name="application_name" type="string" val="drunc-controller"/>
  <attr name="commandline_parameters" type="string">
   <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
-  <data val="grpc://np04-srv-019:3335"/><!-- ALTER_ME -->
+  <data val="grpc:/localhost:3335"/><!-- ALTER_ME -->
   <data val="trg-segment"/>
   <data val="test-session"/>
  </attr>


### PR DESCRIPTION
This PR:
- Uses environment variables in the CLI of the applications, such that we don't need to manually specify things that get reused, and can change them once and for all in the Session DAL.
- Correct a couple of bugs in the name of the application CLI.
- Makes the HSI work with drunc.