### PR TITLE
Command line param method in Application DAL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,25 +16,25 @@ find_package(coredal REQUIRED)
 
 #find_package(Boost COMPONENTS unit_test_framework REQUIRED)
 
-daq_oks_codegen(application.schema.xml fdmodules.schema.xml trigger.schema.xml 
+daq_oks_codegen(application.schema.xml fdmodules.schema.xml trigger.schema.xml
   NAMESPACE dunedaq::appdal DEP_PKGS coredal)
 
+
 daq_add_library(ReadoutApplication.cpp SmartDaqApplication.cpp
-	DFApplication.cpp DFOApplication.cpp TPWriterApplication.cpp FakeDataApplication.cpp FakeHSIApplication.cpp TriggerApplication.cpp MLTApplication.cpp HSIEventToTCApplication.cpp 
+	DFApplication.cpp DFOApplication.cpp TPWriterApplication.cpp FakeDataApplication.cpp FakeHSIApplication.cpp TriggerApplication.cpp MLTApplication.cpp HSIEventToTCApplication.cpp
  LINK_LIBRARIES oksdbinterfaces::oksdbinterfaces okssystem::okssystem
   logging::logging coredal::coredal oks::oks ers::ers)
 
+daq_add_application(getAppsArguments get_apps_arguments.cxx
+  LINK_LIBRARIES coredal appdal oksdbinterfaces::oksdbinterfaces)
 
-daq_add_python_bindings(dal_methods.cpp module.cpp LINK_LIBRARIES 
-  appdal coredal::coredal)
-
+daq_add_python_bindings(*.cpp LINK_LIBRARIES appdal coredal::coredal)
 
 daq_add_application(generate_modules_test generate_modules_test.cxx
  TEST LINK_LIBRARIES appdal coredal::coredal oksdbinterfaces::oksdbinterfaces
  logging::logging)
 
 ##############################################################################
-
 
 # See https://dune-daq-sw.readthedocs.io/en/latest/packages/daq-cmake/#daq_add_unit_test
 

--- a/apps/get_apps_arguments.cxx
+++ b/apps/get_apps_arguments.cxx
@@ -1,0 +1,73 @@
+#include "logging/Logging.hpp"
+
+#include "oksdbinterfaces/Configuration.hpp"
+
+#include "coredal/Component.hpp"
+#include "coredal/DaqApplication.hpp"
+#include "coredal/RCApplication.hpp"
+#include "coredal/DaqModule.hpp"
+#include "coredal/ResourceSet.hpp"
+#include "coredal/Segment.hpp"
+#include "coredal/Session.hpp"
+
+#include "appdal/SmartDaqApplication.hpp"
+
+#include <iostream>
+#include <string>
+
+using namespace dunedaq;
+
+
+void print_segment_application_commandline(
+  const dunedaq::coredal::Segment* segment,
+  const dunedaq::coredal::Session* session,
+  oksdbinterfaces::Configuration* db) {
+
+  auto const* controller = segment->get_controller();
+
+    std::cout << "\n" << controller->UID() << "\n";
+    for (auto const& CLA: controller->construct_commandline_parameters(*db, session))
+      std::cout << "CLA: " << CLA << "\n";
+
+    for (auto const& app: segment->get_applications()) {
+      std::cout << "\n" << app->UID() << "\n";
+      std::vector<std::string> CLAs;
+      if (app->castable("SmartDaqApplication")) {
+        auto const* sdapp = db->get<dunedaq::appdal::SmartDaqApplication>(app->UID());
+        CLAs = sdapp->construct_commandline_parameters(*db, session);
+      } else if (app->castable("DaqApplication")) {
+        auto const* dapp = db->get<dunedaq::appdal::SmartDaqApplication>(app->UID());
+        CLAs = dapp->construct_commandline_parameters(*db, session);
+      } else {
+        CLAs = app->get_commandline_parameters();
+      }
+
+      for (auto const& CLA: CLAs)
+        std::cout << "CLA: " << CLA << "\n";
+    }
+
+  for (auto const& segment: segment->get_segments())
+    print_segment_application_commandline(segment, session, db);
+
+}
+
+
+int main(int argc, char* argv[]) {
+  dunedaq::logging::Logging::setup();
+
+  if (argc < 3) {
+    std::cout << "Usage: " << argv[0] << " session database-file\n";
+    return 0;
+  }
+  std::string confimpl = "oksconfig:" + std::string(argv[2]);
+  auto confdb = new oksdbinterfaces::Configuration(confimpl);
+
+  std::string sessionName(argv[1]);
+  auto session = confdb->get<coredal::Session>(sessionName);
+  if (session==nullptr) {
+    std::cerr << "Session " << sessionName << " not found in database\n";
+    return -1;
+  }
+
+  print_segment_application_commandline(session->get_segment(), session, confdb);
+}

--- a/pybindsrc/dal_methods.cpp
+++ b/pybindsrc/dal_methods.cpp
@@ -27,7 +27,7 @@ namespace dunedaq::appdal::python {
 
   struct ObjectLocator {
     ObjectLocator(const std::string& id_arg, const std::string& class_name_arg) :
-      id(id_arg), class_name(class_name_arg) 
+      id(id_arg), class_name(class_name_arg)
       {}
     const std::string id;
     const std::string class_name;
@@ -38,7 +38,7 @@ namespace dunedaq::appdal::python {
   application_generate_template(const oksdbinterfaces::Configuration& confdb,
                                 const std::string& dbfile,
                                 const std::string& app_id,
-                                const std::string& session_id) 
+                                const std::string& session_id)
   {
     auto app =
       const_cast<oksdbinterfaces::Configuration&>(confdb).get<ApplicationType>(app_id);
@@ -51,6 +51,14 @@ namespace dunedaq::appdal::python {
       mods.push_back({mod->UID(),mod->class_name()});
     }
     return mods;
+  }
+
+  std::vector<std::string> smart_daq_application_construct_commandline_parameters(const oksdbinterfaces::Configuration& db,
+                                                                                  const std::string& session_id,
+                                                                                  const std::string& app_id) {
+    const auto* app = const_cast<oksdbinterfaces::Configuration&>(db).get<dunedaq::appdal::SmartDaqApplication>(app_id);
+    const auto* session = const_cast<oksdbinterfaces::Configuration&>(db).get<dunedaq::coredal::Session>(session_id);
+    return app->construct_commandline_parameters(db, session);
   }
 
 void
@@ -67,6 +75,7 @@ register_dal_methods(py::module& m)
   m.def("dfo_application_generate", &application_generate_template<DFOApplication>, "Generate DaqModules required by DFOApplication");
   m.def("tpwriter_application_generate", &application_generate_template<TPStreamWriterApplication>, "Generate DaqModules required by TPStreamWriterApplication");
   m.def("trigger_application_generate", &application_generate_template<TriggerApplication>, "Generate DaqModules required by TriggerApplication");
+  m.def("smart_daq_application_construct_commandline_parameters", &smart_daq_application_construct_commandline_parameters, "Get a version of the command line agruments parsed");
 }
 
 } // namespace dunedaq::appdal::python

--- a/schema/appdal/application.schema.xml
+++ b/schema/appdal/application.schema.xml
@@ -372,6 +372,9 @@
   <method name="generate_modules" description="">
    <method-implementation language="c++" prototype="virtual std::vector&lt;const dunedaq::coredal::DaqModule*&gt; generate_modules(oksdbinterfaces::Configuration*, const std::string&amp;, const coredal::Session*) const" body=""/>
   </method>
+  <method name="construct_commandline_parameters" description="get the command line parameters for this application">
+   <method-implementation language="c++" prototype=" const std::vector&lt;std::string&gt; construct_commandline_parameters(const oksdbinterfaces::Configuration&amp; confdb, const dunedaq::coredal::Session* session) const" body="BEGIN_HEADER_PROLOGUE&#xA;#include &quot;coredal/util.hpp&quot;&#xA;END_HEADER_PROLOGUE"/>
+  </method>
  </class>
 
  <class name="SourceIDConf">

--- a/scripts/app_environment_cli
+++ b/scripts/app_environment_cli
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+
+import sys
+
+import coredal
+import appdal
+import oksdbinterfaces
+import logging
+from rich.console import Console
+from rich.logging import RichHandler
+import os
+try:
+    screen_width = os.get_terminal_size()[1]
+except:
+    screen_width = 150
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="\"%(name)s\": %(message)s",
+    datefmt="[%X]",
+    handlers=[
+        RichHandler(rich_tracebacks=False, tracebacks_width=screen_width) # Make this True, and everything crashes on exceptions (no clue why)
+    ]
+)
+
+log = logging.getLogger("app_environment")
+console = Console()
+
+dal = oksdbinterfaces.dal.module('x', 'schema/coredal/dunedaq.schema.xml')
+
+# Process a dal::Variable object, placing key/value pairs in a dictionary
+def process_variables(variables, envDict):
+  for item in variables:
+    if item.className() == 'VariableSet':
+      process_variables(item.contains, envDict)
+    else:
+      if item.className() == 'Variable':
+        envDict[item.name] = item.value
+
+# Recursively process all Segments in given Segment extracting Applications
+def process_segment(db, session, segment):
+  controller = segment.controller.id
+
+  # Get default environment from Session
+  defenv = {}
+  process_variables(session.environment, defenv)
+
+  apps = []
+
+  # Recurse over nested segments
+  for seg in segment.segments:
+    if coredal.component_disabled(db._obj, session.id, seg.id):
+      print(f"Ignoring disabled segment {seg.id}")
+      continue
+    apps += process_segment(db, session, seg)
+
+  rc_env = defenv
+  process_variables(segment.controller.applicationEnvironment, rc_env)
+  rc_host = segment.controller.runs_on.runs_on.id
+
+  CLA_constructor = coredal.rc_application_construct_commandline_parameters
+  apps.append(
+    (
+      segment.controller.id,
+      rc_host,
+      rc_env,
+      [segment.controller.application_name] + CLA_constructor(db._obj, session.id, segment.controller.id),
+      session.rte_script,
+    )
+  )
+
+  # Get all the enabled applications of this segment
+  for app in segment.applications:
+    console.print(f"Considering app \'{app.id}\'")
+    if 'Component' in app.oksTypes():
+      enabled = not coredal.component_disabled(db._obj, session.id, app.id)
+      log.debug(f"{app.id} {enabled=}")
+    else:
+      enabled = True
+      log.debug(f"{app.id} {enabled=}")
+
+    if not enabled:
+      continue
+
+    appenv = defenv
+    # Override with any app specific environment from Application
+    process_variables(app.applicationEnvironment, appenv)
+    if 'DaqApplication' in app.oksTypes():
+      CLA_constructor = coredal.daq_application_construct_commandline_parameters
+    elif "SmartDaqApplication"  in app.oksTypes():
+      CLA_constructor = appdal.smart_daq_application_construct_commandline_parameters
+
+
+    host = app.runs_on.runs_on.id
+    apps.append(
+      (
+        app.id,
+        host,
+        appenv,
+        [app.application_name]+CLA_constructor(db._obj, session.id, app.id),
+        session.rte_script,
+      )
+    )
+
+  return apps
+
+
+def main():
+  if len(sys.argv) != 3:
+    print(f"Usage: {sys.argv[0]} <path-to-oks-data-file> <session-name>")
+    return
+  db = oksdbinterfaces.Configuration("oksconfig:" + sys.argv[1])
+  session_name = sys.argv[2]
+  session = db.get_dal(class_name="Session", uid=session_name)
+
+  environment = {}
+  process_variables(session.environment, environment)
+
+  apps = process_segment(db, session, session.segment)
+
+  console.print("Applications")
+  for a in apps:
+    console.rule()
+    pretty_env = []
+    for k,v in a[2].items():
+      pretty_env += [f" - \'{k}\': {v}"]
+    pretty_env = "\n".join(pretty_env)
+    console.print(f'''[bold]app:[/] \'{a[0]}\'
+[bold]host:[/] \'{a[1]}\'
+[bold]env:[/]
+{pretty_env}
+[bold]commandline:[/]
+  {" ".join(a[3])}
+[bold]rte_script:[/] \'{a[4]}\'
+''')
+
+
+if __name__ == '__main__':
+    main()

--- a/src/SmartDaqApplication.cpp
+++ b/src/SmartDaqApplication.cpp
@@ -2,6 +2,7 @@
 #include "appdal/SmartDaqApplication.hpp"
 #include "appdal/appdalIssues.hpp"
 #include "oks/kernel.hpp"
+#include "coredal/util.hpp"
 
 using namespace dunedaq::appdal;
 
@@ -15,4 +16,10 @@ SmartDaqApplication::generate_modules(oksdbinterfaces::Configuration* confdb,
                                             confdb,
                                             dbfile,
                                             session);
+}
+
+const std::vector<std::string> SmartDaqApplication::construct_commandline_parameters(
+    const oksdbinterfaces::Configuration& confdb,
+    const dunedaq::coredal::Session* session) const {
+    return dunedaq::coredal::construct_commandline_parameters_appfwk<dunedaq::appdal::SmartDaqApplication>(this, confdb, session);
 }

--- a/test/config/df-segment.data.xml
+++ b/test/config/df-segment.data.xml
@@ -121,22 +121,9 @@
 
 <obj class="DFApplication" id="df-01">
  <attr name="application_name" type="string" val="daq_application"/>
-<<<<<<< HEAD
  <rel name="exposes_service">
   <ref class="Service" id="df-01_control">
  </rel>
-=======
- <attr name="commandline_parameters" type="string">
-  <data val="--name"/>
-  <data val="df-01"/>
-  <data val="-c"/>
-  <data val="rest://localhost:3339"/>
-  <data val="-i"/>
-  <data val="${DAQAPP_CLI_INFO_SVC}"/>
-  <data val="--configurationService"/>
-  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
- </attr>
->>>>>>> develop
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="source_id" class="SourceIDConf" id="srcid-df-01"/>
  <rel name="queue_rules">
@@ -157,22 +144,9 @@
 
 <obj class="DFApplication" id="df-02">
  <attr name="application_name" type="string" val="daq_application"/>
-<<<<<<< HEAD
  <rel name="exposes_service">
   <ref class="Service" id="df-02_control">
  </rel>
-=======
- <attr name="commandline_parameters" type="string">
-  <data val="--name"/>
-  <data val="df-02"/>
-  <data val="-c"/>
-  <data val="rest://localhost:3340"/>
-  <data val="-i"/>
-  <data val="${DAQAPP_CLI_INFO_SVC}"/>
-  <data val="--configurationService"/>
-  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
- </attr>
->>>>>>> develop
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="source_id" class="SourceIDConf" id="srcid-df-02"/>
  <rel name="queue_rules">
@@ -193,19 +167,6 @@
 
 <obj class="DFApplication" id="df-03">
  <attr name="application_name" type="string" val="daq_application"/>
-<<<<<<< HEAD
-=======
- <attr name="commandline_parameters" type="string">
-  <data val="--name"/>
-  <data val="df-03"/>
-  <data val="-c"/>
-  <data val="rest://localhost:3341"/>
-  <data val="-i"/>
-  <data val="${DAQAPP_CLI_INFO_SVC}"/>
-  <data val="--configurationService"/>
-  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
- </attr>
->>>>>>> develop
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="source_id" class="SourceIDConf" id="srcid-df-03"/>
  <rel name="exposes_service">

--- a/test/config/df-segment.data.xml
+++ b/test/config/df-segment.data.xml
@@ -86,19 +86,42 @@
  <comment creation-time="20240312T202726" created-by="eflumerf" created-on="ironvirt9.mshome.net" author="eflumerf" text="Trivial edit to reorder objects"/>
 </comments>
 
+<obj class="Service" id="df-controller_control">
+  <attr name="protocol" val="grpc"/>
+  <attr name="port" val="5600"/>
+</obj>
+
+<obj class="Service" id="df-01_control">
+  <attr name="protocol" val="rest"/>
+  <attr name="port" val="5601"/>
+</obj>
+
+<obj class="Service" id="df-02_control">
+  <attr name="protocol" val="rest"/>
+  <attr name="port" val="5602"/>
+</obj>
+
+<obj class="Service" id="df-03_control">
+  <attr name="protocol" val="rest"/>
+  <attr name="port" val="5603"/>
+</obj>
+
+<obj class="Service" id="dfo-01_control">
+  <attr name="protocol" val="rest"/>
+  <attr name="port" val="5604"/>
+</obj>
+
+<obj class="Service" id="tp-stream-writer_control">
+  <attr name="protocol" val="rest"/>
+  <attr name="port" val="5605"/>
+</obj>
+
 
 <obj class="DFApplication" id="df-01">
  <attr name="application_name" type="string" val="daq_application"/>
- <attr name="commandline_parameters" type="string">
-  <data val="--name"/>
-  <data val="df-01"/>
-  <data val="-c"/>
-  <data val="rest://localhost:3339"/><!-- ALTER_ME -->
-  <data val="-i"/>
-  <data val="${DAQAPP_CLI_INFO_SVC}"/>
-  <data val="--configurationService"/>
-  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
- </attr>
+ <rel name="exposes_service">
+  <ref class="Service" id="df-01_control">
+ </rel>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="source_id" class="SourceIDConf" id="srcid-df-01"/>
  <rel name="queue_rules">
@@ -118,16 +141,9 @@
 
 <obj class="DFApplication" id="df-02">
  <attr name="application_name" type="string" val="daq_application"/>
- <attr name="commandline_parameters" type="string">
-  <data val="--name"/>
-  <data val="df-02"/>
-  <data val="-c"/>
-  <data val="rest://localhost:3340"/><!-- ALTER_ME -->
-  <data val="-i"/>
-  <data val="${DAQAPP_CLI_INFO_SVC}"/>
-  <data val="--configurationService"/>
-  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
- </attr>
+ <rel name="exposes_service">
+  <ref class="Service" id="df-02_control">
+ </rel>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="source_id" class="SourceIDConf" id="srcid-df-02"/>
  <rel name="queue_rules">
@@ -146,18 +162,11 @@
 
 <obj class="DFApplication" id="df-03">
  <attr name="application_name" type="string" val="daq_application"/>
- <attr name="commandline_parameters" type="string">
-  <data val="--name"/>
-  <data val="df-03"/>
-  <data val="-c"/>
-  <data val="rest://localhost:3341"/><!-- ALTER_ME -->
-  <data val="-i"/>
-  <data val="${DAQAPP_CLI_INFO_SVC}"/>
-  <data val="--configurationService"/>
-  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
- </attr>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="source_id" class="SourceIDConf" id="srcid-df-03"/>
+ <rel name="exposes_service">
+  <ref class="Service" id="df-03_control">
+ </rel>
  <rel name="queue_rules">
   <ref class="QueueConnectionRule" id="trigger-record-q-rule"/>
  </rel>
@@ -180,16 +189,9 @@
 
 <obj class="DFOApplication" id="dfo-01">
  <attr name="application_name" type="string" val="daq_application"/>
- <attr name="commandline_parameters" type="string">
-  <data val="--name"/>
-  <data val="dfo-01"/>
-  <data val="-c"/>
-  <data val="rest://localhost:3342"/><!-- ALTER_ME -->
-  <data val="-i"/>
-  <data val="${DAQAPP_CLI_INFO_SVC}"/>
-  <data val="--configurationService"/>
-  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
- </attr>
+ <rel name="exposes_service">
+  <ref class="Service" id="dfo-01_control">
+ </rel>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="network_rules">
   <ref class="NetworkConnectionRule" id="td-dfo-net-rule"/>
@@ -233,12 +235,9 @@
 
 <obj class="RCApplication" id="df-controller">
  <attr name="application_name" type="string" val="drunc-controller"/>
- <attr name="commandline_parameters" type="string">
-  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
-  <data val="grpc://localhost:3338"/><!-- ALTER_ME -->
-  <data val="df-segment"/>
-  <data val="test-session"/>
- </attr>
+ <rel name="exposes_service">
+  <ref class="Service" id="df-controller_control">
+ </rel>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="fsm" class="FSMconfiguration" id="fsmConf-1"/>
  <rel name="broadcaster" class="RCBroadcaster" id="broadcaster-root"/>
@@ -247,16 +246,9 @@
 <obj class="TPStreamWriterApplication" id="tp-stream-writer">
  <attr name="application_name" type="string" val="daq_application"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
- <attr name="commandline_parameters" type="string">
-  <data val="--name"/>
-  <data val="tp-stream-writer"/>
-  <data val="-c"/>
-  <data val="rest://localhost:3343"/><!-- ALTER_ME -->
-  <data val="-i"/>
-  <data val="${DAQAPP_CLI_INFO_SVC}"/>
-  <data val="--configurationService"/>
-  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
- </attr>
+ <rel name="exposes_service">
+  <ref class="Service" id="tp-stream-writer_control">
+ </rel>
   <rel name="source_id" class="SourceIDConf" id="srcid-tp-stream-writer"/>
  <rel name="network_rules">
   <ref class="NetworkConnectionRule" id="tp-net-rule"/>

--- a/test/config/hosts.data.xml
+++ b/test/config/hosts.data.xml
@@ -100,4 +100,31 @@
  <rel name="runs_on" class="PhysicalHost" id="localhost"/>
 </obj>
 
+
+<obj class="PhysicalHost" id="monkafka.cern.ch">
+ <rel name="contains">
+  <ref class="ProcessingResource" id="localhost_cpus"/>
+ </rel>
+</obj>
+
+<obj class="VirtualHost" id="kafka-cern-vhost">
+ <rel name="uses">
+  <ref class="ProcessingResource" id="localhost_cpus"/>
+ </rel>
+ <rel name="runs_on" class="PhysicalHost" id="monkafka.cern.ch"/>
+</obj>
+
+<obj class="PhysicalHost" id="pocket-host"> <!-- ALTER_ME -->
+ <rel name="contains">
+  <ref class="ProcessingResource" id="localhost_cpus"/>
+ </rel>
+</obj>
+
+<obj class="VirtualHost" id="kafka-pocket-vhost">
+ <rel name="uses">
+  <ref class="ProcessingResource" id="localhost_cpus"/>
+ </rel>
+ <rel name="runs_on" class="PhysicalHost" id="pocket-host"/> <!-- ALTER_ME -->
+</obj>
+
 </oks-data>

--- a/test/config/hsi-segment.data.xml
+++ b/test/config/hsi-segment.data.xml
@@ -81,21 +81,21 @@
  <comment creation-time="20240312T203031" created-by="eflumerf" created-on="ironvirt9.mshome.net" author="eflumerf" text="Apply source_id..."/>
 </comments>
 
+<obj class="Service" id="hsi-controller_control">
+  <attr name="protocol" val="grpc"/>
+  <attr name="port" val="5800"/>
+</obj>
+
+<obj class="Service" id="hsi-01_control">
+  <attr name="protocol" val="rest"/>
+  <attr name="port" val="5801"/>
+</obj>
+
 
 <obj class="FakeHSIApplication" id="hsi-01">
  <attr name="application_name" type="string" val="daq_application"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="source_id" class="SourceIDConf" id="hsi-srcid-01"/>
- <attr name="commandline_parameters" type="string">
-  <data val="--name"/>
-  <data val="hsi-01"/>
-  <data val="-c"/>
-  <data val="rest://localhost:3382"/><!-- ALTER_ME -->
-  <data val="-i"/>
-  <data val="${DAQAPP_CLI_INFO_SVC}"/>
-  <data val="--configurationService"/>
-  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
- </attr>
  <rel name="queue_rules">
   <ref class="QueueConnectionRule" id="hsi-raw-data-rule"/>
  </rel>
@@ -103,6 +103,9 @@
   <ref class="NetworkConnectionRule" id="hsi-data-req-net-rule"/>
   <ref class="NetworkConnectionRule" id="hsi-ts-net-rule"/>
   <ref class="NetworkConnectionRule" id="hsi-rule"/>
+ </rel>
+ <rel name="exposes_service">
+  <ref class="Service" id="hsi-01_control">
  </rel>
  <rel name="link_handler" class="ReadoutModuleConf" id="def-hsi-handler"/>
  <rel name="generator" class="FakeHSIEventGeneratorConf" id="fakehsi"/>
@@ -132,13 +135,10 @@
 <obj class="RCApplication" id="hsi-controller">
  <attr name="application_name" type="string" val="drunc-controller"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
+ <rel name="exposes_service">
+  <ref class="Service" id="hsi-controller_control">
+ </rel>
  <rel name="fsm" class="FSMconfiguration" id="fsmConf-1"/>
- <attr name="commandline_parameters" type="string">
-  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
-  <data val="grpc://localhost:3498"/><!-- ALTER_ME -->
-  <data val="hsi-segment"/>
-  <data val="test-session"/>
- </attr>
  <rel name="broadcaster" class="RCBroadcaster" id="broadcaster-root"/>
 </obj>
 

--- a/test/config/ru-segment.data.xml
+++ b/test/config/ru-segment.data.xml
@@ -93,38 +93,46 @@
     <attr name="publish_timeout" type="u32" val="2"/>
 </obj>
 
+<obj class="Service" id="ru-controller_control">
+  <attr name="protocol" val="grpc"/>
+  <attr name="port" val="5500"/>
+</obj>
+
+<obj class="Service" id="ru-01_control">
+  <attr name="protocol" val="rest"/>
+  <attr name="port" val="5501"/>
+</obj>
+
+<obj class="Service" id="ru-02_control">
+  <attr name="protocol" val="rest"/>
+  <attr name="port" val="5502"/>
+</obj>
+
+<obj class="Service" id="ru-03_control">
+  <attr name="protocol" val="rest"/>
+  <attr name="port" val="5503"/>
+</obj>
+
 <obj class="RCApplication" id="ru-controller">
  <attr name="application_name" type="string" val="drunc-controller"/>
- <attr name="commandline_parameters" type="string">
-  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
-  <data val="grpc://localhost:3334"/><!-- ALTER_ME -->
-  <data val="ru-segment"/>
-  <data val="test-session"/>
- </attr>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="fsm" class="FSMconfiguration" id="fsmConf-1"/>
  <rel name="broadcaster" class="RCBroadcaster" id="broadcaster-root"/>
+ <rel name="exposes_service">
+  <ref class="Service" id="ru-controller_control">
+ </rel>
 </obj>
 
 <obj class="ReadoutApplication" id="ru-01">
  <attr name="tp_source_id" type="u32" val="100"/>
  <attr name="ta_source_id" type="u32" val="1000"/>
  <attr name="application_name" type="string" val="daq_application"/>
- <attr name="commandline_parameters" type="string">
-  <data val="--name"/>
-  <data val="ru-01"/>
-  <data val="-c"/>
-  <data val="rest://localhost:4335"/><!-- ALTER_ME -->
-  <data val="-i"/>
-  <data val="${DAQAPP_CLI_INFO_SVC}"/>
-  <data val="--configurationService"/>
-  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
- </attr>
  <rel name="contains">
   <ref class="ReadoutGroup" id="rog-1"/>
  </rel>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
+  <ref class="Service" id="ru-01_control">
   <ref class="Service" id="dataRequests"/>
   <ref class="Service" id="timeSyncs"/>
   <ref class="Service" id="triggerActivities"/>
@@ -152,20 +160,13 @@
  <attr name="tp_source_id" type="u32" val="200"/>
  <attr name="ta_source_id" type="u32" val="2000"/>
  <attr name="application_name" type="string" val="daq_application"/>
- <attr name="commandline_parameters" type="string">
-  <data val="--name"/>
-  <data val="ru-02"/>
-  <data val="-c"/>
-  <data val="rest://localhost:4336"/><!-- ALTER_ME -->
-  <data val="-i"/>
-  <data val="${DAQAPP_CLI_INFO_SVC}"/>
-  <data val="--configurationService"/>
-  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
- </attr>
  <rel name="contains">
   <ref class="ReadoutGroup" id="rog-2"/>
  </rel>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
+ <rel name="exposes_service">
+  <ref class="Service" id="ru-02_control">
+ </rel>
  <rel name="queue_rules">
   <ref class="QueueConnectionRule" id="fa-queue-rule"/>
   <ref class="QueueConnectionRule" id="data-requests-queue-rule"/>
@@ -188,21 +189,13 @@
  <attr name="tp_source_id" type="u32" val="300"/>
  <attr name="ta_source_id" type="u32" val="3000"/>
  <attr name="application_name" type="string" val="daq_application"/>
- <attr name="commandline_parameters" type="string">
-  <data val="--name"/>
-  <data val="ru-03"/>
-  <data val="-c"/>
-  <data val="rest://localhost:4337"/><!-- ALTER_ME -->
-  <data val="-i"/>
-  <data val="${DAQAPP_CLI_INFO_SVC}"/>
-  <data val="--configurationService"/>
-  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
-
- </attr>
  <rel name="contains">
   <ref class="ReadoutGroup" id="rog-3"/>
  </rel>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
+ <rel name="exposes_service">
+  <ref class="Service" id="ru-03_control">
+ </rel>
  <rel name="queue_rules">
   <ref class="QueueConnectionRule" id="fa-queue-rule"/>
   <ref class="QueueConnectionRule" id="data-requests-queue-rule"/>

--- a/test/config/test-session.data.xml
+++ b/test/config/test-session.data.xml
@@ -93,17 +93,20 @@
  <attr name="op_env" type="string" val="test"/>
 </obj>
 
+<obj class="Service" id="root-controller_control">
+ <attr name="protocol" type="string" val="grpc"/>
+ <attr name="port" type="u16" val="3333"/>
+ <attr name="eth_device_name" type="string" val=""/>
+</obj>
+
 <obj class="RCApplication" id="root-controller">
- <attr name="commandline_parameters" type="string">
-  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
-  <data val="grpc://localhost:3333"/><!-- ALTER_ME -->
-  <data val="root-segment"/>
-  <data val="test-session"/>
- </attr>
  <attr name="application_name" type="string" val="drunc-controller"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="fsm" class="FSMconfiguration" id="fsmConf-1"/>
  <rel name="broadcaster" class="RCBroadcaster" id="broadcaster-root"/>
+ <rel name="exposes_service">
+   <ref class="Service" id="root-controller_control">
+ </rel>
 </obj>
 
 <obj class="Segment" id="root-segment">
@@ -117,12 +120,72 @@
 </obj>
 
 
+<obj class="Service" id="daq-k8s-opmon-service">
+    <attr name="protocol" val="kafka"/>
+    <attr name="port" val="30092"/>
+    <attr name="path" val="/opmon"/>
+</obj>
+
+<obj class="Service" id="local-opmon-service">
+    <attr name="protocol" val="file"/>
+    <attr name="port" val=""/>
+    <attr name="path" val="info.json"/> <!-- BUG, should be keyed with the application name, which isn't available here... Hopefully, this behaves correctly and appends the file for all the apps... (-_o) see you on the other side -->
+</obj>
+
+<obj class="OpMonService" id="cern-opmon-application-service">
+ <attr name="application_name" val="sh"> <!-- just in case someone has the idea to do something with infrastructure_applications... -->
+ <attr name="commandline_parameters" type="string">
+  <data val="-c"/>
+  <data val="echo Not starting kafka/grafana/postgres/influx"/>
+  <data val="&amp;&amp;"/>
+  <data val="sleep 10000"/>
+ </attr>
+ <rel name="runs_on" class="VirtualHost" id="kafka-cern-vhost"/>
+ <rel name="exposes_service">
+   <ref class="Service" id="daq-k8s-opmon-service">
+ </rel>
+</obj>
+
+<obj class="OpMonService" id="pocket-opmon-application-service">
+ <attr name="application_name" val="sh"> <!-- just in case someone has the idea to do something with infrastructure_applications... -->
+ <attr name="commandline_parameters" type="string">
+  <data val="-c"/>
+  <data val="echo Not starting kafka/grafana/postgres/influx"/>
+  <data val="&amp;&amp;"/>
+  <data val="sleep 10000"/>
+ </attr>
+ <rel name="runs_on" class="VirtualHost" id="kafka-pocket-vhost"/>
+ <rel name="exposes_service">
+   <ref class="Service" id="daq-k8s-opmon-service">
+ </rel>
+</obj>
+
+<obj class="OpMonService" id="local-opmon-application-service">
+ <attr name="application_name" val="sh"> <!-- just in case someone has the idea to do something with infrastructure_applications... -->
+ <attr name="commandline_parameters" type="string">
+  <data val="-c"/>
+  <data val="echo This service doesnt need any executable"/>
+  <data val="&amp;&amp;"/>
+  <data val="sleep 10000"/>
+ </attr>
+ <rel name="runs_on" class="VirtualHost" id="vlocalhost"/><!-- whatever, really -->
+ <rel name="exposes_service">
+   <ref class="Service" id="local-opmon-service">
+ </rel>
+</obj>
+
+
+
 <obj class="Session" id="test-session">
- <attr name="use_connectivity_server" type="bool" val="1"/>
+ <attr name="use_connectivity_server" type="bool" val="1"/> <!-- Should delete and check for connectivity_service in infrastructure_application instead -->
  <attr name="connectivity_service_interval_ms" type="u32" val="2000"/>
  <attr name="data_request_timeout_ms" type="u32" val="1000"/>
  <attr name="data_rate_slowdown_factor" type="u32" val="1"/>
- <attr name="rte_script" type="string" val="/point/to/your/install/daq_app_rte.sh"><!-- ALTER_ME -->
+ <attr name="rte_script" type="string" val="/nfs/home/plasorak/fddaq-v5.0.0-rc1-a9/swdir/install/daq_app_rte.sh"><!-- ALTER_ME -->
+ <rel name="infrastructure_applications">
+  <ref class="OpMonService" id="cern-opmon-application-service">
+  <!--   <ref name="connectivity_service" id="session-connectivity_service"> -->
+ </rel>
  <rel name="environment">
   <ref class="Variable" id="session-env-session-name-0"/>
   <ref class="Variable" id="session-env-session-name-1"/>

--- a/test/config/trigger-segment.data.xml
+++ b/test/config/trigger-segment.data.xml
@@ -89,6 +89,32 @@
  <comment creation-time="20240312T203446" created-by="eflumerf" created-on="ironvirt9.mshome.net" author="eflumerf" text="Add application source_id entries"/>
 </comments>
 
+<obj class="Service" id="trg-controller_control">
+  <attr name="protocol" val="grpc"/>
+  <attr name="port" val="5700"/>
+</obj>
+
+<obj class="Service" id="hsi-to-tc-app_control">
+  <attr name="protocol" val="rest"/>
+  <attr name="port" val="5701"/>
+</obj>
+
+<obj class="Service" id="mlt_control">
+  <attr name="protocol" val="rest"/>
+  <attr name="port" val="5702"/>
+</obj>
+
+<obj class="Service" id="tc-maker-1_control">
+  <attr name="protocol" val="rest"/>
+  <attr name="port" val="5703"/>
+</obj>
+
+<obj class="Service" id="tc-buffer-1_control">
+  <attr name="protocol" val="rest"/>
+  <attr name="port" val="5704"/>
+</obj>
+
+
 
 <obj class="CustomTriggerCandidateMakerConf" id="cstm-tc-generator">
  <attr name="timestamp_method" type="enum" val="kTimeSync"/>
@@ -132,19 +158,12 @@
  <attr name="application_name" type="string" val="daq_application"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="source_id" class="SourceIDConf" id="hsi-tc-srcid-1"/>
- <attr name="commandline_parameters" type="string">
-  <data val="--name"/>
-  <data val="hsi-to-tc-app"/>
-  <data val="-c"/>
-  <data val="rest://localhost:3348"/><!-- ALTER_ME -->
-  <data val="-i"/>
-  <data val="${DAQAPP_CLI_INFO_SVC}"/>
-  <data val="--configurationService"/>
-  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
- </attr>
  <rel name="network_rules">
   <ref class="NetworkConnectionRule" id="hsi-rule"/>
   <ref class="NetworkConnectionRule" id="tc-mlt-rule"/>
+ </rel>
+ <rel name="exposes_service">
+  <ref class="Service" id="hsi-to-tc-app_control">
  </rel>
  <rel name="hsevent_to_tc_conf" class="HSI2TCTranslatorConf" id="hsi-to-tc-conf"/>
 </obj>
@@ -159,20 +178,13 @@
  <attr name="application_name" type="string" val="daq_application"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="source_id" class="SourceIDConf" id="mlt-srcid-01"/>
- <attr name="commandline_parameters" type="string">
-  <data val="--name"/>
-  <data val="mlt"/>
-  <data val="-c"/>
-  <data val="rest://localhost:3346"/><!-- ALTER_ME -->
-  <data val="-i"/>
-  <data val="${DAQAPP_CLI_INFO_SVC}"/>
-  <data val="--configurationService"/>
-  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
- </attr>
  <rel name="network_rules">
   <ref class="NetworkConnectionRule" id="tc-net-rule"/>
   <ref class="NetworkConnectionRule" id="ti-net-rule"/>
   <ref class="NetworkConnectionRule" id="td-dfo-net-rule"/>
+ </rel>
+ <rel name="exposes_service">
+  <ref class="Service" id="mlt_control">
  </rel>
  <rel name="mlt_conf" class="ModuleLevelTriggerConf" id="mlt-conf"/>
  <rel name="standalone_candidate_maker_confs">
@@ -198,14 +210,11 @@
 
 <obj class="RCApplication" id="trg-controller">
  <attr name="application_name" type="string" val="drunc-controller"/>
- <attr name="commandline_parameters" type="string">
-  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
-  <data val="grpc:/localhost:3335"/><!-- ALTER_ME -->
-  <data val="trg-segment"/>
-  <data val="test-session"/>
- </attr>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="fsm" class="FSMconfiguration" id="fsmConf-1"/>
+ <rel name="exposes_service">
+  <ref class="Service" id="trg-controller_control">
+ </rel>
  <rel name="broadcaster" class="RCBroadcaster" id="broadcaster-root"/>
 </obj>
 
@@ -323,18 +332,9 @@
 
 <obj class="TriggerApplication" id="tc-buffer-1">
  <attr name="application_name" type="string" val="daq_application"/>
- <attr name="commandline_parameters" type="string">
-  <data val="--name"/>
-  <data val="tc-buffer-1"/>
-  <data val="-c"/>
-  <data val="rest://localhost:3344"/><!-- ALTER_ME -->
-  <data val="-i"/>
-  <data val="${DAQAPP_CLI_INFO_SVC}"/>
-  <data val="--configurationService"/>
-  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
- </attr>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
+  <ref class="Service" id="tc-buffer-1_control">
   <ref class="Service" id="dataRequests"/>
   <ref class="Service" id="triggerCandidates"/>
  </rel>
@@ -353,18 +353,9 @@
 
 <obj class="TriggerApplication" id="tc-maker-1">
  <attr name="application_name" type="string" val="daq_application"/>
- <attr name="commandline_parameters" type="string">
-  <data val="--name"/>
-  <data val="tc-maker-1"/>
-  <data val="-c"/>
-  <data val="rest://localhost:3345"/><!-- ALTER_ME -->
-  <data val="-i"/>
-  <data val="${DAQAPP_CLI_INFO_SVC}"/>
-  <data val="--configurationService"/>
-  <data val="${DAQAPP_CLI_CONFIG_SVC}"/>
- </attr>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
  <rel name="exposes_service">
+  <ref class="Service" id="tc-maker-1_control">
   <ref class="Service" id="triggerActivities"/>
  </rel>
  <rel name="source_id" class="SourceIDConf" id="tc-srcid-1"/>


### PR DESCRIPTION
This PR is related to https://github.com/DUNE-DAQ/coredal/pull/18

This PR contains:
 - an example of the implementation of the DAL changes described in `coredal` (new `OpmonService`, new control `Service` for each application)
 - an implementation of a configuration method to get the command line parameters for `SmartDaqApplication` (which uses the same templated function used for `DaqApplication` in `coredal/include/util.hpp`)
 - python bindings for the above method
 - some handy executable to access command line parameters and environment (python ones are in `scripts` and c++ in `app`)