### PR TITLE
WIECApplication module generation

### DIFF
--- a/config/appmodel/wiecconfs.data.xml
+++ b/config/appmodel/wiecconfs.data.xml
@@ -63,7 +63,7 @@
 
 <oks-data>
 
-<info name="" type="" num-of-items="6" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T105629" last-modified-by="glehmann" last-modified-on="np04-srv-024.cern.ch" last-modification-time="20240617T145813"/>
+<info name="" type="" num-of-items="7" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T105629" last-modified-by="thea" last-modified-on="np04-srv-031.cern.ch" last-modification-time="20240618T084833"/>
 
 <include>
  <file path="schema/appmodel/wiec.schema.xml"/>
@@ -71,9 +71,19 @@
 
 <comments>
  <comment creation-time="20240617T145813" created-by="glehmann" created-on="np04-srv-024.cern.ch" author="glehmann" text=" "/>
+ <comment creation-time="20240618T084833" created-by="thea" created-on="np04-srv-031.cern.ch" author="thea" text="ipbus timeout increased to 10"/>
 </comments>
 
+
 <obj class="ColdADCSettings" id="def-coldadc-settings">
+ <attr name="reg_0" type="u8" val="35"/>
+ <attr name="reg_4" type="u8" val="59"/>
+ <attr name="reg_24" type="u8" val="223"/>
+ <attr name="reg_25" type="u8" val="51"/>
+ <attr name="reg_26" type="u8" val="137"/>
+ <attr name="reg_27" type="u8" val="103"/>
+ <attr name="reg_29" type="u8" val="39"/>
+ <attr name="reg_30" type="u8" val="39"/>
 </obj>
 
 <obj class="FEMBSettings" id="def-femb-settings">
@@ -96,6 +106,7 @@
 <obj class="HermesModuleConf" id="def-hermes-conf">
  <attr name="ipbus_type" type="string" val="ipbusudp-2.0"/>
  <attr name="ipbus_port" type="u32" val="50001"/>
+ <attr name="ipbus_timeout_ms" type="u32" val="10000"/>
  <rel name="address_table" class="IpbusAddressTable" id="Hermes-addrtab"/>
 </obj>
 

--- a/schema/appmodel/application.schema.xml
+++ b/schema/appmodel/application.schema.xml
@@ -80,7 +80,7 @@
 
 <oks-schema>
 
-<info name="" type="" num-of-items="47" oks-format="schema" oks-version="oks-08-03-04-11-g3f5bde7 built &quot;Feb 21 2023&quot;" created-by="gjc" created-on="thinkpad" creation-time="20230616T091343" last-modified-by="glehmann" last-modified-on="np04-srv-024.cern.ch" last-modification-time="20240612T160058"/>
+<info name="" type="" num-of-items="47" oks-format="schema" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20230616T091343" last-modified-by="thea" last-modified-on="np04-srv-031.cern.ch" last-modification-time="20240618T084639"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
@@ -122,15 +122,6 @@
   <relationship name="configuration" class-type="DFOConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
  </class>
 
- <class name="DataHandlerModule" is-abstract="yes">
-  <superclass name="DaqModule"/>
-  <attribute name="source_id" type="u32" is-not-null="yes"/>
-  <attribute name="detector_id" type="u32" is-not-null="yes"/>
-  <attribute name="emulation_mode" type="bool" init-value="false" is-not-null="yes"/>
-  <relationship name="geo_id" class-type="GeoId" low-cc="zero" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
-  <relationship name="module_configuration" class-type="DataHandlerConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
- </class>
-
  <class name="DataHandlerConf">
   <attribute name="template_for" type="class" init-value="DataHandlerModule" is-not-null="yes"/>
   <attribute name="input_data_type" description="Type of data received by this readout module" type="string" init-value="WIBEthFrame"/>
@@ -141,16 +132,19 @@
   <relationship name="data_processor" class-type="DataProcessor" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
  </class>
 
+ <class name="DataHandlerModule" is-abstract="yes">
+  <superclass name="DaqModule"/>
+  <attribute name="source_id" type="u32" is-not-null="yes"/>
+  <attribute name="detector_id" type="u32" is-not-null="yes"/>
+  <attribute name="emulation_mode" type="bool" init-value="false" is-not-null="yes"/>
+  <relationship name="geo_id" class-type="GeoId" low-cc="zero" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
+  <relationship name="module_configuration" class-type="DataHandlerConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
+ </class>
+
  <class name="DataProcessor">
   <attribute name="queue_sizes" type="u32" init-value="10000"/>
   <attribute name="thread_names_prefix" type="string" init-value="postproc-"/>
   <attribute name="mask_processing" description="Flag to comment out post processing in a data processor" type="bool" init-value="false"/>
- </class>
-
- <class name="DataReceiverModule" is-abstract="yes">
-  <superclass name="DaqModule"/>
-  <relationship name="configuration" class-type="DataReceiverConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
-  <relationship name="connections" class-type="DetectorToDaqConnection" low-cc="one" high-cc="many" is-composite="yes" is-exclusive="no" is-dependent="no"/>
  </class>
 
  <class name="DataReceiverConf">
@@ -159,9 +153,10 @@
   <relationship name="emulation_conf" description="Parameters for emulating the stream." class-type="StreamEmulationParameters" low-cc="zero" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
  </class>
 
- <class name="DataRecorderModule" is-abstract="yes">
+ <class name="DataReceiverModule" is-abstract="yes">
   <superclass name="DaqModule"/>
-  <relationship name="configuration" class-type="DataRecorderConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
+  <relationship name="configuration" class-type="DataReceiverConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
+  <relationship name="connections" class-type="DetectorToDaqConnection" low-cc="one" high-cc="many" is-composite="yes" is-exclusive="no" is-dependent="no"/>
  </class>
 
  <class name="DataRecorderConf">
@@ -169,6 +164,11 @@
   <attribute name="streaming_buffer_size" type="u32" init-value="1000" is-not-null="yes"/>
   <attribute name="compression_algorithm" type="string" init-value="None" is-not-null="yes"/>
   <attribute name="use_o_direct" description="Whether to use O_DIRECT flag when opening files" type="bool" init-value="true"/>
+ </class>
+
+ <class name="DataRecorderModule" is-abstract="yes">
+  <superclass name="DaqModule"/>
+  <relationship name="configuration" class-type="DataRecorderConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
  </class>
 
  <class name="DataStoreConf">
@@ -182,17 +182,17 @@
   <relationship name="filename_params" class-type="FilenameParams" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
  </class>
 
- <class name="DataWriterModule">
-  <superclass name="DaqModule"/>
-  <relationship name="configuration" class-type="DataWriterConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
- </class>
-
  <class name="DataWriterConf">
   <attribute name="data_storage_prescale" type="s32" init-value="1" is-not-null="yes"/>
   <attribute name="min_write_retry_time_ms" type="s32" init-value="0" is-not-null="yes"/>
   <attribute name="max_write_retry_time_ms" type="s32" init-value="0" is-not-null="yes"/>
   <attribute name="write_retry_time_increase_factor" type="s32" init-value="0" is-not-null="yes"/>
   <relationship name="data_store_params" class-type="DataStoreConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
+ </class>
+
+ <class name="DataWriterModule">
+  <superclass name="DaqModule"/>
+  <relationship name="configuration" class-type="DataWriterConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
  </class>
 
  <class name="FakeDataApplication">
@@ -202,11 +202,6 @@
   <method name="generate_modules" description="Generate daq module dal objects for streams of the FakeDataApplication on the fly">
    <method-implementation language="c++" prototype="std::vector&lt;const dunedaq::confmodel::DaqModule*&gt; generate_modules(conffwk::Configuration*, const std::string&amp;, const confmodel::Session*) const override" body=""/>
   </method>
- </class>
-
- <class name="FakeDataProdModule">
-  <superclass name="DaqModule"/>
-  <relationship name="configuration" class-type="FakeDataProdConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
  </class>
 
  <class name="FakeDataProdConf">
@@ -219,6 +214,11 @@
   <attribute name="fragment_type" description="Fragment type of the response" type="string" is-not-null="yes"/>
  </class>
 
+ <class name="FakeDataProdModule">
+  <superclass name="DaqModule"/>
+  <relationship name="configuration" class-type="FakeDataProdConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
+ </class>
+
  <class name="FakeHSIApplication">
   <superclass name="SmartDaqApplication"/>
   <relationship name="link_handler" class-type="DataHandlerConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
@@ -226,11 +226,6 @@
   <method name="generate_modules" description="Generate DaqModule dal objects for streams of the application on the fly">
    <method-implementation language="c++" prototype="std::vector&lt;const dunedaq::confmodel::DaqModule*&gt; generate_modules(conffwk::Configuration*, const std::string&amp;, const confmodel::Session*) const override" body=""/>
   </method>
- </class>
-
- <class name="FakeHSIEventGeneratorModule">
-  <superclass name="DaqModule"/>
-  <relationship name="configuration" class-type="FakeHSIEventGeneratorConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
  </class>
 
  <class name="FakeHSIEventGeneratorConf">
@@ -241,6 +236,11 @@
   <attribute name="mean_signal_multiplicity" description="Mean number of edges expected per signal. Used when signal emulation mode is 1" type="u32" init-value="1" is-not-null="yes"/>
   <attribute name="enabled_signals" description="Which signals or bit of the 32 bit signal bit map are enabled, i.e. could produce an emulated signal" type="u32" init-value="0" is-not-null="yes"/>
   <attribute name="signal_emulation_mode" description="Signal bit map emulation mode. 0: enabled signals always on; 1: enabled signals are emulated (independently) on according to a Poisson with mean mean_signal_multiplicity; signal map generated with uniform distr. enabled signals only" type="u32" init-value="0" is-not-null="yes"/>
+ </class>
+
+ <class name="FakeHSIEventGeneratorModule">
+  <superclass name="DaqModule"/>
+  <relationship name="configuration" class-type="FakeHSIEventGeneratorConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
  </class>
 
  <class name="FilenameParams">
@@ -402,12 +402,6 @@
   <attribute name="TP_rate_per_channel" description="TP rate per channel in units of 100 Hz." type="float" init-value="0.0" is-not-null="yes"/>
  </class>
 
- <class name="TPStreamWriterModule">
-  <superclass name="DaqModule"/>
-  <attribute name="source_id" type="u32" is-not-null="yes"/>
-  <relationship name="configuration" class-type="TPStreamWriterConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
- </class>
-
  <class name="TPStreamWriterApplication">
   <superclass name="SmartDaqApplication"/>
   <relationship name="tp_writer" class-type="TPStreamWriterConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
@@ -419,6 +413,12 @@
  <class name="TPStreamWriterConf">
   <attribute name="tp_accumulation_interval" type="u64" init-value="0" is-not-null="yes"/>
   <relationship name="data_store_params" class-type="DataStoreConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
+ </class>
+
+ <class name="TPStreamWriterModule">
+  <superclass name="DaqModule"/>
+  <attribute name="source_id" type="u32" is-not-null="yes"/>
+  <relationship name="configuration" class-type="TPStreamWriterConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
  </class>
 
  <class name="TRBConf">

--- a/schema/appmodel/fdmodules.schema.xml
+++ b/schema/appmodel/fdmodules.schema.xml
@@ -80,7 +80,7 @@
 
 <oks-schema>
 
-<info name="" type="" num-of-items="17" oks-format="schema" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20230616T091343" last-modified-by="thea" last-modified-on="np04-srv-031.cern.ch" last-modification-time="20240617T100440"/>
+<info name="" type="" num-of-items="11" oks-format="schema" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20230616T091343" last-modified-by="thea" last-modified-on="np04-srv-031.cern.ch" last-modification-time="20240618T084639"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
@@ -153,6 +153,7 @@
 
  <class name="IpbusDevice">
   <attribute name="uri" type="string" is-not-null="yes"/>
+  <attribute name="timeout_ms" description="IPBus device timeout" type="u32" init-value="1000" is-not-null="yes"/>
   <relationship name="address_table" class-type="IpbusAddressTable" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
  </class>
 

--- a/schema/appmodel/wiec.schema.xml
+++ b/schema/appmodel/wiec.schema.xml
@@ -80,13 +80,14 @@
 
 <oks-schema>
 
-<info name="" type="" num-of-items="18" oks-format="schema" oks-version="oks-08-03-04-11-g3f5bde7 built &quot;Feb 21 2023&quot;" created-by="gjc" created-on="thinkpad" creation-time="20230616T091343" last-modified-by="glehmann" last-modified-on="np04-srv-024.cern.ch" last-modification-time="20240611T170050"/>
+<info name="" type="" num-of-items="10" oks-format="schema" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20230616T091343" last-modified-by="thea" last-modified-on="np04-srv-031.cern.ch" last-modification-time="20240618T084639"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
  <file path="schema/appmodel/application.schema.xml"/>
  <file path="schema/appmodel/fdmodules.schema.xml"/>
 </include>
+
 
  <class name="ColdADCSettings" description="Customized ColdADC register settings">
   <attribute name="reg_0" description="Register 0: sdc_bypassed" type="u8" init-value="35" is-not-null="yes"/>
@@ -118,13 +119,6 @@
   <attribute name="pulse_channels" description="Array of up to 16 true/false values, for whether to send pulser to each corresponding channel per LArASIC." type="bool" is-multi-value="yes"/>
  </class>
 
-  <class name="HermesModule">
-  <superclass name="DaqModule"/>
-  <superclass name="IpbusDevice"/>
-  <relationship name="links" class-type="HermesDataSender" low-cc="one" high-cc="many" is-composite="no" is-exclusive="no" is-dependent="no"/>
-  <relationship name="destination" class-type="NetworkInterface" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
- </class>
-
  <class name="HermesDataSender">
   <superclass name="NWDetDataSender"/>
   <attribute name="link_id" type="u32" is-not-null="yes"/>
@@ -132,17 +126,30 @@
   <attribute name="control_host" type="string" init-value="localhost" is-not-null="yes"/>
  </class>
 
+ <class name="HermesModule">
+  <superclass name="DaqModule"/>
+  <superclass name="IpbusDevice"/>
+  <relationship name="links" class-type="HermesDataSender" low-cc="one" high-cc="many" is-composite="no" is-exclusive="no" is-dependent="no"/>
+  <relationship name="destination" class-type="NetworkInterface" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
+ </class>
+
  <class name="HermesModuleConf">
   <attribute name="ipbus_type" type="string" init-value="ipbusudp-2.0" is-not-null="yes"/>
   <attribute name="ipbus_port" type="u32" init-value="50001" is-not-null="yes"/>
+  <attribute name="ipbus_timeout_ms" type="u32" init-value="1000" is-not-null="yes"/>
   <relationship name="address_table" class-type="IpbusAddressTable" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
  </class>
-
 
  <class name="WIBConfigurator">
   <superclass name="DaqModule"/>
   <attribute name="wib_addr" type="string" init-value="tcp://192.168.121.1:1234" is-not-null="yes"/>
   <relationship name="conf" class-type="WIBSettings" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
+ </class>
+
+ <class name="WIBModuleConf">
+  <attribute name="communication_type" type="string" init-value="tcp" is-not-null="yes"/>
+  <attribute name="communication_port" type="u32" init-value="1234" is-not-null="yes"/>
+  <relationship name="settings" class-type="WIBSettings" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
  </class>
 
  <class name="WIBPulserSettings" description="WIB Pulser settings">
@@ -169,17 +176,11 @@
   <relationship name="wib_pulser" description="Settings for WIB pulser" class-type="WIBPulserSettings" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
  </class>
 
- <class name="WIBModuleConf">
-  <attribute name="communication_type" type="string" init-value="tcp" is-not-null="yes"/>
-  <attribute name="communication_port" type="u32" init-value="1234" is-not-null="yes"/>
-  <relationship name="settings" class-type="WIBSettings" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
- </class>
-
  <class name="WIECApplication" description="Application describing the controller of a detector unit using WIBs inside a WIEC.">
   <superclass name="SmartDaqApplication"/>
   <superclass name="ResourceSetAND"/>
-  <relationship name="wib_module_conf" class-type="WIBModuleConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
-  <relationship name="hermes_module_conf" class-type="HermesModuleConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
+  <relationship name="wib_module_conf" class-type="WIBModuleConf" low-cc="zero" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
+  <relationship name="hermes_module_conf" class-type="HermesModuleConf" low-cc="zero" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <method name="generate_modules" description="Generate DaqModule dal objects for streams of the application on the fly">
    <method-implementation language="c++" prototype="std::vector&lt;const dunedaq::confmodel::DaqModule*&gt; generate_modules(conffwk::Configuration*, const std::string&amp;, const confmodel::Session*) const override" body=""/>
   </method>

--- a/src/DFApplication.cpp
+++ b/src/DFApplication.cpp
@@ -193,8 +193,8 @@ DFApplication::generate_modules(conffwk::Configuration* confdb,
   }
   uint dw_idx = 0;
   for ( auto dwrConf :dwrConfs ) {
-    auto fnParamsObj = dwrConf->get_data_store_params()->get_filename_params()->config_object();
-    fnParamsObj.set_by_val<std::string>("writer_identifier", fmt::format("{}_datawriter-{}", UID(), dw_idx));
+    // auto fnParamsObj = dwrConf->get_data_store_params()->get_filename_params()->config_object();
+    // fnParamsObj.set_by_val<std::string>("writer_identifier", fmt::format("{}_datawriter-{}", UID(), dw_idx));
     auto dwrConfObj = dwrConf->config_object();
 
     // Prepare DataWriterModule Module Object and assign its Config Object.

--- a/src/WIECApplication.cpp
+++ b/src/WIECApplication.cpp
@@ -126,6 +126,7 @@ WIECApplication::generate_modules(conffwk::Configuration* config,
         config->create(dbfile, "HermesModule", hermes_uid, hermes_obj);
         hermes_obj.set_obj("address_table", &this->get_hermes_module_conf()->get_address_table()->config_object());
         hermes_obj.set_by_val<std::string>("uri", fmt::format("{}://{}:{}", this->get_hermes_module_conf()->get_ipbus_type(), ctrlhost, this->get_hermes_module_conf()->get_ipbus_port()));
+        hermes_obj.set_by_val<uint32_t>("timeout_ms", this->get_hermes_module_conf()->get_ipbus_timeout_ms());
         hermes_obj.set_obj("destination", &nw_receiver->get_uses()->config_object());
 
         std::vector< const conffwk::ConfigObject * > links_obj; 

--- a/src/WIECApplication.cpp
+++ b/src/WIECApplication.cpp
@@ -42,5 +42,49 @@ WIECApplication::generate_modules(conffwk::Configuration* confdb,
 {
   std::vector<const confmodel::DaqModule*> modules;
 
+
+
+  uint16_t conn_idx = 0;
+  for (auto d2d_conn_res : get_contains()) {
+
+    // Are we sure?
+    if (d2d_conn_res->disabled(*session)) {
+      TLOG_DEBUG(7) << "Ignoring disabled DetectorToDaqConnection " << d2d_conn_res->UID();
+      continue;
+    }
+
+    d2d_conn_objs.push_back(&d2d_conn_res->config_object());
+
+    TLOG() << "Processing DetectorToDaqConnection " << d2d_conn_res->UID();
+    // get the readout groups and the interfaces and streams therein; 1 reaout group corresponds to 1 data reader module
+    auto d2d_conn = d2d_conn_res->cast<confmodel::DetectorToDaqConnection>();
+
+    if (!d2d_conn) {
+      throw(BadConf(ERS_HERE, "ReadoutApplication contains something other than DetectorToDaqConnection"));
+    }
+
+    if (d2d_conn->get_contains().empty()) {
+      throw(BadConf(ERS_HERE, "DetectorToDaqConnection does not contain sebders or receivers"));
+    }
+
+    // Loop over detector 2 daq connections to find senders and receivers
+    auto det_senders = d2d_conn->get_senders();
+    auto det_receiver = d2d_conn->get_receiver();
+
+    // Loop over senders
+    for (auto stream : d2d_conn->get_streams()) {
+
+      // Are we sure?
+      if (stream->disabled(*session)) {
+        TLOG_DEBUG(7) << "Ignoring disabled DetectorStream " << stream->UID();
+        continue;
+      }
+
+      // loop over streams
+      det_streams.push_back(stream);
+    }
+
+  }
+
   return modules;
 }

--- a/test/config/CRP4-session.data.xml
+++ b/test/config/CRP4-session.data.xml
@@ -63,7 +63,7 @@
 
 <oks-data>
 
-<info name="" type="" num-of-items="22" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20240306T144154" last-modified-by="glehmann" last-modified-on="np04-srv-024.cern.ch" last-modification-time="20240617T145813"/>
+<info name="" type="" num-of-items="30" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20240306T144154" last-modified-by="thea" last-modified-on="np04-srv-031.cern.ch" last-modification-time="20240618T085408"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
@@ -85,13 +85,16 @@
  <comment creation-time="20240307T133917" created-by="glehmann" created-on="np04-srv-024.cern.ch" author="Unknown" text="disable TPG"/>
  <comment creation-time="20240426T073141" created-by="thea" created-on="np02-srv-001.cern.ch" author="thea" text="enabling callbacks"/>
  <comment creation-time="20240430T135210" created-by="thea" created-on="np02-srv-001.cern.ch" author="thea" text="Removed ta source id"/>
- <comment creation-time="20240617T092318" created-by="thea" created-on="np04-srv-031.cern.ch" author="thea" text="sorting"/>
  <comment creation-time="20240616T202116" created-by="thea" created-on="np04-srv-031.cern.ch" author="thea" text="added fsm prod to ru-controller"/>
  <comment creation-time="20240616T204242" created-by="thea" created-on="np04-srv-031.cern.ch" author="thea" text="adding control services"/>
  <comment creation-time="20240616T204340" created-by="thea" created-on="np04-srv-031.cern.ch" author="thea" text="setting ru apps control services"/>
  <comment creation-time="20240616T210618" created-by="thea" created-on="np04-srv-031.cern.ch" author="thea" text="adding opmon"/>
  <comment creation-time="20240616T211218" created-by="thea" created-on="np04-srv-031.cern.ch" author="thea" text="root rules"/>
  <comment creation-time="20240617T054038" created-by="thea" created-on="np04-srv-031.cern.ch" author="thea" text="setting env"/>
+ <comment creation-time="20240617T092318" created-by="thea" created-on="np04-srv-031.cern.ch" author="thea" text="sorting"/>
+ <comment creation-time="20240618T072215" created-by="thea" created-on="np04-srv-031.cern.ch" author="thea" text="WIB removed from WIEC app"/>
+ <comment creation-time="20240618T082100" created-by="thea" created-on="np04-srv-031.cern.ch" author="thea" text="adding erskafka as extra stream lib"/>
+ <comment creation-time="20240618T085408" created-by="thea" created-on="np04-srv-031.cern.ch" author="thea" text="adding wibmods back"/>
 </comments>
 
 
@@ -160,7 +163,7 @@
   <ref class="Service" id="ru-controller_control"/>
  </rel>
  <rel name="fsm" class="FSMconfiguration" id="FSMconfiguration_noAction"/>
-  <rel name="broadcaster" class="RCBroadcaster" id="broadcaster-root"/>
+ <rel name="broadcaster" class="RCBroadcaster" id="broadcaster-root"/>
 </obj>
 
 <obj class="ReadoutApplication" id="runp02srv003eth0">
@@ -198,7 +201,6 @@
  <rel name="segments">
   <ref class="Segment" id="ru-segment"/>
   <ref class="Segment" id="df-segment"/>
-  <ref class="Segment" id="trg-segment"/>
  </rel>
  <rel name="controller" class="RCApplication" id="root-controller"/>
 </obj>
@@ -259,6 +261,7 @@
   <ref class="Variable" id="session-env-connectivity-port"/>
   <ref class="Variable" id="daqapp-cli-monitoring"/>
   <ref class="Variable" id="daqapp-cli-configuration"/>
+  <ref class="Variable" id="session-env-ers-stream-libs"/>
  </rel>
  <rel name="segment" class="Segment" id="root-segment"/>
  <rel name="infrastructure_applications">
@@ -300,6 +303,12 @@
 <obj class="Variable" id="session-env-ers-info">
  <attr name="name" type="string" val="DUNEDAQ_ERS_INFO"/>
  <attr name="value" type="string" val="erstrace,throttle,lstdout,protobufstream(monkafka.cern.ch:30092)"/>
+</obj>
+
+<obj class="Variable" id="session-env-ers-stream-libs">
+ <attr name="description" type="string" val="List of extra ERS streaming libs"/>
+ <attr name="name" type="string" val="DUNEDAQ_ERS_STREAM_LIBS"/>
+ <attr name="value" type="string" val="erskafka"/>
 </obj>
 
 <obj class="Variable" id="session-env-ers-verb">

--- a/test/config/CRP4-session.data.xml
+++ b/test/config/CRP4-session.data.xml
@@ -260,7 +260,7 @@
   <ref class="Variable" id="daqapp-cli-monitoring"/>
   <ref class="Variable" id="daqapp-cli-configuration"/>
  </rel>
- <rel name="segment" class="Segment" id="ru-segment"/>
+ <rel name="segment" class="Segment" id="root-segment"/>
  <rel name="infrastructure_applications">
   <ref class="OpMonService" id="cern-opmon-application-service"/>
  </rel>

--- a/test/config/CRP4-session.data.xml
+++ b/test/config/CRP4-session.data.xml
@@ -207,7 +207,7 @@
 
 <obj class="Segment" id="ru-segment">
  <rel name="applications">
-  <ref class="WIECApplication" id="hermes-CRP4"/>
+  <ref class="WIECApplication" id="wiec-crp4"/>
   <ref class="ReadoutApplication" id="runp02srv003eth0"/>
  </rel>
  <rel name="controller" class="RCApplication" id="ru-controller"/>
@@ -219,7 +219,7 @@
  <attr name="path" type="string" val="/opmon"/>
 </obj>
 
-<obj class="Service" id="hermes-CRP4_control">
+<obj class="Service" id="wiec-crp4_control">
  <attr name="protocol" type="string" val="rest"/>
  <attr name="port" type="u16" val="5401"/>
 </obj>

--- a/test/config/df-segment.data.xml
+++ b/test/config/df-segment.data.xml
@@ -63,7 +63,7 @@
 
 <oks-data>
 
-<info name="" type="" num-of-items="17" oks-format="data" oks-version="oks-08-03-04-11-g3f5bde7 built &quot;Feb 21 2023&quot;" created-by="gjc" created-on="thinkpad" creation-time="20231207T105629" last-modified-by="glehmann" last-modified-on="np04-srv-019.cern.ch" last-modification-time="20240325T124934"/>
+<info name="" type="" num-of-items="23" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T105629" last-modified-by="thea" last-modified-on="np04-srv-031.cern.ch" last-modification-time="20240617T203421"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
@@ -86,45 +86,16 @@
  <comment creation-time="20240307T084519" created-by="glehmann" created-on="np04-srv-024.cern.ch" author="Unknown" text="added dataflow"/>
  <comment creation-time="20240312T202726" created-by="eflumerf" created-on="ironvirt9.mshome.net" author="eflumerf" text="Trivial edit to reorder objects"/>
  <comment creation-time="20240325T124934" created-by="glehmann" created-on="np04-srv-019.cern.ch" author="Unknown" text="adjusted to name changes in connections"/>
+ <comment creation-time="20240617T203421" created-by="thea" created-on="np04-srv-031.cern.ch" author="thea" text="adding datawriters"/>
 </comments>
-
-<obj class="Service" id="df-controller_control">
-  <attr name="protocol" val="grpc"/>
-  <attr name="port" val="5600"/>
-</obj>
-
-<obj class="Service" id="df-01_control">
-  <attr name="protocol" val="rest"/>
-  <attr name="port" val="5601"/>
-</obj>
-
-<obj class="Service" id="df-02_control">
-  <attr name="protocol" val="rest"/>
-  <attr name="port" val="5602"/>
-</obj>
-
-<obj class="Service" id="df-03_control">
-  <attr name="protocol" val="rest"/>
-  <attr name="port" val="5603"/>
-</obj>
-
-<obj class="Service" id="dfo-01_control">
-  <attr name="protocol" val="rest"/>
-  <attr name="port" val="5604"/>
-</obj>
-
-<obj class="Service" id="tp-stream-writer_control">
-  <attr name="protocol" val="rest"/>
-  <attr name="port" val="5605"/>
-</obj>
 
 
 <obj class="DFApplication" id="df-01">
  <attr name="application_name" type="string" val="daq_application"/>
- <rel name="exposes_service">
-  <ref class="Service" id="df-01_control">
- </rel>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
+ <rel name="exposes_service">
+  <ref class="Service" id="df-01_control"/>
+ </rel>
  <rel name="source_id" class="SourceIDConf" id="srcid-df-01"/>
  <rel name="queue_rules">
   <ref class="QueueConnectionRule" id="trigger-record-q-rule"/>
@@ -138,16 +109,18 @@
   <ref class="NetworkConnectionRule" id="data-req-trig-net-rule"/>
  </rel>
  <rel name="trb" class="TRBConf" id="trb-01"/>
- <rel name="data_writer" class="DataWriterConf" id="dw-01"/>
+ <rel name="data_writers">
+  <ref class="DataWriterConf" id="dw-01"/>
+ </rel>
  <rel name="uses" class="DFHWConf" id="dfhw-01"/>
 </obj>
 
 <obj class="DFApplication" id="df-02">
  <attr name="application_name" type="string" val="daq_application"/>
- <rel name="exposes_service">
-  <ref class="Service" id="df-02_control">
- </rel>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
+ <rel name="exposes_service">
+  <ref class="Service" id="df-02_control"/>
+ </rel>
  <rel name="source_id" class="SourceIDConf" id="srcid-df-02"/>
  <rel name="queue_rules">
   <ref class="QueueConnectionRule" id="trigger-record-q-rule"/>
@@ -161,17 +134,19 @@
   <ref class="NetworkConnectionRule" id="data-req-trig-net-rule"/>
  </rel>
  <rel name="trb" class="TRBConf" id="trb-01"/>
- <rel name="data_writer" class="DataWriterConf" id="dw-01"/>
+ <rel name="data_writers">
+  <ref class="DataWriterConf" id="dw-01"/>
+ </rel>
  <rel name="uses" class="DFHWConf" id="dfhw-01"/>
 </obj>
 
 <obj class="DFApplication" id="df-03">
  <attr name="application_name" type="string" val="daq_application"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
- <rel name="source_id" class="SourceIDConf" id="srcid-df-03"/>
  <rel name="exposes_service">
-  <ref class="Service" id="df-03_control">
+  <ref class="Service" id="df-03_control"/>
  </rel>
+ <rel name="source_id" class="SourceIDConf" id="srcid-df-03"/>
  <rel name="queue_rules">
   <ref class="QueueConnectionRule" id="trigger-record-q-rule"/>
  </rel>
@@ -184,7 +159,9 @@
   <ref class="NetworkConnectionRule" id="data-req-trig-net-rule"/>
  </rel>
  <rel name="trb" class="TRBConf" id="trb-01"/>
- <rel name="data_writer" class="DataWriterConf" id="dw-01"/>
+ <rel name="data_writers">
+  <ref class="DataWriterConf" id="dw-01"/>
+ </rel>
  <rel name="uses" class="DFHWConf" id="dfhw-01"/>
 </obj>
 
@@ -196,10 +173,10 @@
 
 <obj class="DFOApplication" id="dfo-01">
  <attr name="application_name" type="string" val="daq_application"/>
- <rel name="exposes_service">
-  <ref class="Service" id="dfo-01_control">
- </rel>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
+ <rel name="exposes_service">
+  <ref class="Service" id="dfo-01_control"/>
+ </rel>
  <rel name="network_rules">
   <ref class="NetworkConnectionRule" id="td-dfo-net-rule"/>
   <ref class="NetworkConnectionRule" id="ti-net-rule"/>
@@ -220,11 +197,10 @@
 </obj>
 
 <obj class="FilenameParams" id="tp-file-params">
- <attr name="overall_prefix" type="string" val="tpstream"/>
+ <attr name="file_type_prefix" type="enum" val="raw"/>
  <attr name="run_number_prefix" type="string" val="run"/>
  <attr name="digits_for_run_number" type="s32" val="6"/>
  <attr name="digits_for_file_index" type="s32" val="4"/>
- <attr name="writer_identifier" type="string" val="tp_writer"/>
  <attr name="digits_for_trigger_number" type="s32" val="6"/>
 </obj>
 
@@ -242,10 +218,10 @@
 
 <obj class="RCApplication" id="df-controller">
  <attr name="application_name" type="string" val="drunc-controller"/>
- <rel name="exposes_service">
-  <ref class="Service" id="df-controller_control">
- </rel>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
+ <rel name="exposes_service">
+  <ref class="Service" id="df-controller_control"/>
+ </rel>
  <rel name="fsm" class="FSMconfiguration" id="FSMconfiguration_noAction"/>
  <rel name="broadcaster" class="RCBroadcaster" id="broadcaster-root"/>
 </obj>
@@ -258,6 +234,36 @@
   <ref class="DFApplication" id="df-02"/>
  </rel>
  <rel name="controller" class="RCApplication" id="df-controller"/>
+</obj>
+
+<obj class="Service" id="df-01_control">
+ <attr name="protocol" type="string" val="rest"/>
+ <attr name="port" type="u16" val="5601"/>
+</obj>
+
+<obj class="Service" id="df-02_control">
+ <attr name="protocol" type="string" val="rest"/>
+ <attr name="port" type="u16" val="5602"/>
+</obj>
+
+<obj class="Service" id="df-03_control">
+ <attr name="protocol" type="string" val="rest"/>
+ <attr name="port" type="u16" val="5603"/>
+</obj>
+
+<obj class="Service" id="df-controller_control">
+ <attr name="protocol" type="string" val="grpc"/>
+ <attr name="port" type="u16" val="5600"/>
+</obj>
+
+<obj class="Service" id="dfo-01_control">
+ <attr name="protocol" type="string" val="rest"/>
+ <attr name="port" type="u16" val="5604"/>
+</obj>
+
+<obj class="Service" id="tp-stream-writer_control">
+ <attr name="protocol" type="string" val="rest"/>
+ <attr name="port" type="u16" val="5605"/>
 </obj>
 
 <obj class="SourceIDConf" id="srcid-df-01">
@@ -286,10 +292,10 @@
 
 <obj class="TPStreamWriterApplication" id="tp-stream-writer">
  <attr name="application_name" type="string" val="daq_application"/>
- <rel name="exposes_service">
-  <ref class="Service" id="tp-stream-writer_control">
- </rel>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
+ <rel name="exposes_service">
+  <ref class="Service" id="tp-stream-writer_control"/>
+ </rel>
  <rel name="source_id" class="SourceIDConf" id="srcid-tp-stream-writer"/>
  <rel name="network_rules">
   <ref class="NetworkConnectionRule" id="tpset-net-rule"/>


### PR DESCRIPTION
Added the implementation of `WIECApplication::generate_module` based on detector-to-daq connection objects.
The generation algorithm searches for endpoints belonging to the same control host, and uses the list to generate both `WIBconfigurator` and `HermesModule` objects.

The wib/hermes modules will be generated only if the corresponding conf object associated to `WIECApplication` is not null.

The CRP4 configuration has been updated accordingly. Currently the configuration fails because of hermes timeouts when both hermes and wibs are enabled due to the WIB ipbus UDP server failing to reply within the timeout while the WIB logic configuration is being applied