### PR TITLE
Re-introducing bespoke signal TRAP for gunicorn/connectiviy server

### DIFF
--- a/test/config/test-session.data.xml
+++ b/test/config/test-session.data.xml
@@ -115,9 +115,11 @@
 
 
 <obj class="ConnectionService" id="local-connection-server">
- <attr name="application_name" type="string" val="gunicorn"/>
+ <attr name="application_name" type="string" val="echo"/>
  <attr name="commandline_parameters" type="string">
-  <data val="-b 0.0.0.0:5000 --workers=1 --worker-class=gthread --threads=2 --timeout 5000000000 --log-level=debug connection-service.connection-flask:app"/>
+  <data val="Process PID $$;"/>
+  <data val="trap &apos;pkill -INT -P $$&apos; EXIT;"/>
+  <data val="gunicorn -b 0.0.0.0:5000 --workers=1 --worker-class=gthread --threads=2 --timeout 5000000000 --log-level=debug connection-service.connection-flask:app"/>
  </attr>
  <attr name="threads" type="u16" val="1"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>


### PR DESCRIPTION
After the removal from drunc in https://github.com/DUNE-DAQ/drunc/pull/144