### PR TITLE
Changing TA SourceID in test trigger-segment

### DIFF
--- a/test/config/trigger-segment.data.xml
+++ b/test/config/trigger-segment.data.xml
@@ -251,7 +251,7 @@
 </obj>
 
 <obj class="SourceIDConf" id="ta-srcid-1">
- <attr name="sid" type="u32" val="1000"/>
+ <attr name="sid" type="u32" val="1100"/>
  <attr name="subsystem" type="enum" val="Trigger"/>
 </obj>
 


### PR DESCRIPTION
Changed `SourceID` for the TA buffer in the test `trigger-segment`. 
It was exactly the same as the `SourceID` of the TP buffer in `ru-segment` [HERE](https://github.com/DUNE-DAQ/appmodel/blob/3947e62487e616e32b826d5cd0e4c565bdcfdd5f/test/config/ru-segment.data.xml#L110), so  `TRBModule` had seen 2 identical SourceIDs and was not building fragments for any TriggerActivities.

Tested by running `HDF5LIBS_TestDumpRecord` on output raw data file before and after the change. Before the change there's no TriggerActivity fragments, after the change there are TriggerActivity fragments, and they are not-empty for Prescale algorithm, as expected.