### PR TITLE
Updated the file_type_prefix for the TPStream writer to 'tp'

### DIFF
--- a/test/config/df-segment.data.xml
+++ b/test/config/df-segment.data.xml
@@ -198,7 +198,7 @@
 </obj>
 
 <obj class="FilenameParams" id="tp-file-params">
- <attr name="file_type_prefix" type="enum" val="raw"/>
+ <attr name="file_type_prefix" type="enum" val="tp"/>
  <attr name="run_number_prefix" type="string" val="run"/>
  <attr name="digits_for_run_number" type="s32" val="6"/>
  <attr name="digits_for_file_index" type="s32" val="4"/>


### PR DESCRIPTION
When I run a small system using this branch merged with the `kbiery/turn_off_numa` branch in this repo, and I include the `glm/filename_fix` branch in the `dfmodules` repo, I see HDF5 filenames like the following:
```
test_raw_run000151_0000_df-01_df-01-dw-0_20240817T193426.hdf5
test_raw_run000151_0000_df-02_df-02-dw-0_20240817T193426.hdf5
test_tp_run000151_0000_tp-stream-writer_tpwriter-4_20240817T193422.hdf5
```
which looks pretty good.

This PR is for the file_type_prefix in the TPStream writer file, i.e. test_**_tp_**_run000151...