### PR TITLE
Temporary Change To LB Capacity.

### DIFF
--- a/config/appmodel/moduleconfs.data.xml
+++ b/config/appmodel/moduleconfs.data.xml
@@ -145,7 +145,7 @@
 </obj>
 
 <obj class="LatencyBuffer" id="def-latency-buf">
- <attr name="size" type="u32" val="139008"/>
+ <attr name="size" type="u32" val="122000"/>
  <attr name="numa_aware" type="bool" val="1"/>
  <attr name="numa_node" type="s16" val="1"/>
  <attr name="intrinsic_allocator" type="bool" val="1"/>


### PR DESCRIPTION
This should be used as a workaround for testing development and not something that is kept into production. A true solution is still being investigated.

Following the minimal working example on https://github.com/DUNE-DAQ/daqconf/wiki/Setting-up-a-dunedaq-v5.1.0-Development-Area:
* Before this change, `ru-01` has a segmentation fault that is caused by a WIBEth frame expansion;
* After this change, the segmentation fault is gone and the expansion succeeds.