### PR TITLE
choose numa unaware latency buffer

### DIFF
--- a/config/appmodel/moduleconfs.data.xml
+++ b/config/appmodel/moduleconfs.data.xml
@@ -146,11 +146,11 @@
 
 <obj class="LatencyBuffer" id="def-latency-buf">
  <attr name="size" type="u32" val="139008"/>
- <attr name="numa_aware" type="bool" val="1"/>
+ <attr name="numa_aware" type="bool" val="0"/>
  <attr name="numa_node" type="s16" val="1"/>
- <attr name="intrinsic_allocator" type="bool" val="1"/>
+ <attr name="intrinsic_allocator" type="bool" val="0"/>
  <attr name="alignment_size" type="u32" val="4096"/>
- <attr name="preallocation" type="bool" val="1"/>
+ <attr name="preallocation" type="bool" val="0"/>
 </obj>
 
 <obj class="MLTConf" id="def-mlt-conf">


### PR DESCRIPTION
for a generic example, it is better to not rely on numa awareness and intrinsic allocator.