### PR TITLE
Triggeralgs v4 to v5 port

### DIFF
--- a/config/appmodel/moduleconfs.data.xml
+++ b/config/appmodel/moduleconfs.data.xml
@@ -325,4 +325,11 @@
  <attr name="adc_threshold" type="u32" val="1000000"/>
 </obj>
 
+<obj class="TAMakerChannelDistanceAlgorithm" id="ta-maker-channeldistance">
+ <attr name="prescale" type="u32" val="100"/>
+ <attr name="window_length" type="u32" val="10000"/>
+ <attr name="min_tps" type="u32" val="10" />
+ <attr name="max_channel_distance" type="u32" val="5"/>
+</obj>
+
 </oks-data>

--- a/schema/appmodel/trigger.schema.xml
+++ b/schema/appmodel/trigger.schema.xml
@@ -247,12 +247,12 @@
  <class name="TAMakerADCSimpleWindowAlgorithm">
   <superclass name="TAAlgorithm"/>
   <attribute name="adc_threshold" description="Threshold for the ADC integral algorithm" type="u32" init-value="10000" is-not-null="yes"/>
-  <attribute name="window_length" description="Window length (in ticks) for the ADC integral algorithm" type="u32" init-value="10000" is-not-null="yes"/>
+  <attribute name="window_length" description="Window length (in ticks) for the algorithm" type="u32" init-value="10000" is-not-null="yes"/>
  </class>
 
  <class name="TAMakerHorizontalMuonAlgorithm">
   <superclass name="TAAlgorithm"/>
-  <attribute name="window_length" description="Window length (in ticks) for the ADC integral algorithm" type="u32" init-value="10000" is-not-null="yes"/>
+  <attribute name="window_length" description="Window length (in ticks) for the algorithm" type="u32" init-value="10000" is-not-null="yes"/>
   <attribute name="trigger_on_adc" description="Whether to trigger on ADC integral" type="bool" init-value="false" is-not-null="yes"/>
   <attribute name="trigger_on_n_channels" description="Whether to trigger on N Channels" type="bool" init-value="false" is-not-null="yes"/>
   <attribute name="trigger_on_adjacency" description="Whether to trigger on adjacency" type="bool" init-value="false" is-not-null="yes"/>
@@ -293,7 +293,7 @@
 
  <class name="TAMakerMichelElectronAlgorithm">
   <superclass name="TAAlgorithm"/>
-  <attribute name="window_length" description="Window length (in ticks) for the ADC integral algorithm" type="u32" init-value="10000" is-not-null="yes"/>
+  <attribute name="window_length" description="Window length (in ticks) for the algorithm" type="u32" init-value="10000" is-not-null="yes"/>
   <attribute name="adjacency_threshold" description="Threshold for the adjacency algorithm" type="u32" init-value="6" is-not-null="yes"/>
   <attribute name="adjacency_tolerance" description="Tolerance for the number of allowed gaps for the adjacency algorithm" type="u32" init-value="4" is-not-null="yes"/>
  </class>
@@ -301,7 +301,7 @@
 
  <class name="TAMakerPlaneCoincidenceAlgorithm">
   <superclass name="TAAlgorithm"/>
-  <attribute name="window_length" description="Window length (in ticks) for the ADC integral algorithm" type="u32" init-value="10000" is-not-null="yes"/>
+  <attribute name="window_length" description="Window length (in ticks) for the algorithm" type="u32" init-value="10000" is-not-null="yes"/>
   <attribute name="adc_threshold" description="Threshold for the ADC integral algorithm" type="u32" init-value="10000" is-not-null="yes"/>
   <attribute name="adjacency_threshold" description="Threshold for the adjacency algorithm" type="u32" init-value="6" is-not-null="yes"/>
   <attribute name="adjacency_tolerance" description="Tolerance for the number of allowed gaps for the adjacency algorithm" type="u32" init-value="4" is-not-null="yes"/>
@@ -325,9 +325,9 @@
 
  <class name="TCMakerHorizontalMuonAlgorithm">
   <superclass name="TCAlgorithm"/>
+  <attribute name="window_length" description="Window length (in ticks) for the algorithm" type="u32" init-value="10000" is-not-null="yes"/>
   <attribute name="trigger_on_adc" description="Whether to trigger on ADC integral" type="bool" init-value="false" is-not-null="yes"/>
   <attribute name="trigger_on_n_channels" description="Whether to trigger on N Channels" type="bool" init-value="false" is-not-null="yes"/>
-  <attribute name="trigger_on_adjacency" description="Whether to trigger on adjacency" type="bool" init-value="false" is-not-null="yes"/>
   <attribute name="adc_threshold" description="Threshold for the ADC integral algorithm" type="u32" init-value="10000" is-not-null="yes"/>
   <attribute name="n_channels_threshold" description="Threshold for the N Channels algorithm" type="u32" init-value="8" is-not-null="yes"/>
  </class>

--- a/schema/appmodel/trigger.schema.xml
+++ b/schema/appmodel/trigger.schema.xml
@@ -252,6 +252,7 @@
 
  <class name="TAMakerHorizontalMuonAlgorithm">
   <superclass name="TAAlgorithm"/>
+  <attribute name="window_length" description="Window length (in ticks) for the ADC integral algorithm" type="u32" init-value="10000" is-not-null="yes"/>
   <attribute name="trigger_on_adc" description="Whether to trigger on ADC integral" type="bool" init-value="false" is-not-null="yes"/>
   <attribute name="trigger_on_n_channels" description="Whether to trigger on N Channels" type="bool" init-value="false" is-not-null="yes"/>
   <attribute name="trigger_on_adjacency" description="Whether to trigger on adjacency" type="bool" init-value="false" is-not-null="yes"/>
@@ -263,6 +264,56 @@
 
  <class name="TAMakerPrescaleAlgorithm">
   <superclass name="TAAlgorithm"/>
+ </class>
+
+ <class name="TAMakerBundleNAlgorithm">
+  <superclass name="TAAlgorithm"/>
+  <attribute name="bundle_size" description="Size of the bundle, in number of TPs" type="u32" init-value="1" is-not-null="yes"/>
+ </class>
+
+ <class name="TAMakerChannelAdjacencyAlgorithm">
+  <superclass name="TAAlgorithm"/>
+  <attribute name="window_length" description="Window length (in ticks) for the algorithm" type="u32" init-value="10000" is-not-null="yes"/>
+  <attribute name="adjacency_threshold" description="Threshold for the adjacency algorithm" type="u32" init-value="6" is-not-null="yes"/>
+  <attribute name="adjacency_tolerance" description="Tolerance for the number of allowed gaps for the adjacency algorithm" type="u32" init-value="4" is-not-null="yes"/>
+ </class>
+
+ <class name="TAMakerChannelDistanceAlgorithm">
+  <superclass name="TAAlgorithm"/>
+  <attribute name="window_length" description="Window length (in ticks) for the algorithm" type="u32" init-value="10000" is-not-null="yes"/>
+  <attribute name="min_tps" description="Minimum number of adjacent TPs to trigger on" type="u32" init-value="100" is-not-null="yes"/>
+  <attribute name="max_channel_distance" description="Maximum distance between TPs to satisfy Adjacency condition" type="u32" init-value="5" is-not-null="yes"/>
+ </class>
+
+ <class name="TAMakerDBSCANAlgorithm">
+  <superclass name="TAAlgorithm"/>
+  <attribute name="min_pts" description="Minimum number of points in a density unit" type="u32" init-value="5" is-not-null="yes"/>
+  <attribute name="eps" description="Kernel size for the DBSCAN algorithm" type="u32" init-value="10" is-not-null="yes"/>
+ </class>
+
+ <class name="TAMakerMichelElectronAlgorithm">
+  <superclass name="TAAlgorithm"/>
+  <attribute name="window_length" description="Window length (in ticks) for the ADC integral algorithm" type="u32" init-value="10000" is-not-null="yes"/>
+  <attribute name="trigger_on_adc" description="Whether to trigger on ADC integral" type="bool" init-value="false" is-not-null="yes"/>
+  <attribute name="trigger_on_n_channels" description="Whether to trigger on N Channels" type="bool" init-value="false" is-not-null="yes"/>
+  <attribute name="trigger_on_adjacency" description="Whether to trigger on adjacency" type="bool" init-value="false" is-not-null="yes"/>
+  <attribute name="adc_threshold" description="Threshold for the ADC integral algorithm" type="u32" init-value="10000" is-not-null="yes"/>
+  <attribute name="n_channels_threshold" description="Threshold for the N Channels algorithm" type="u32" init-value="8" is-not-null="yes"/>
+  <attribute name="adjacency_threshold" description="Threshold for the adjacency algorithm" type="u32" init-value="6" is-not-null="yes"/>
+  <attribute name="adjacency_tolerance" description="Tolerance for the number of allowed gaps for the adjacency algorithm" type="u32" init-value="4" is-not-null="yes"/>
+ </class>
+
+
+ <class name="TAMakerPlaneCoincidenceAlgorithm">
+  <superclass name="TAAlgorithm"/>
+  <attribute name="window_length" description="Window length (in ticks) for the ADC integral algorithm" type="u32" init-value="10000" is-not-null="yes"/>
+  <attribute name="trigger_on_adc" description="Whether to trigger on ADC integral" type="bool" init-value="false" is-not-null="yes"/>
+  <attribute name="trigger_on_n_channels" description="Whether to trigger on N Channels" type="bool" init-value="false" is-not-null="yes"/>
+  <attribute name="trigger_on_adjacency" description="Whether to trigger on adjacency" type="bool" init-value="false" is-not-null="yes"/>
+  <attribute name="adc_threshold" description="Threshold for the ADC integral algorithm" type="u32" init-value="10000" is-not-null="yes"/>
+  <attribute name="n_channels_threshold" description="Threshold for the N Channels algorithm" type="u32" init-value="8" is-not-null="yes"/>
+  <attribute name="adjacency_threshold" description="Threshold for the adjacency algorithm" type="u32" init-value="6" is-not-null="yes"/>
+  <attribute name="adjacency_tolerance" description="Tolerance for the number of allowed gaps for the adjacency algorithm" type="u32" init-value="4" is-not-null="yes"/>
  </class>
 
  <class name="TriggerApplication">

--- a/schema/appmodel/trigger.schema.xml
+++ b/schema/appmodel/trigger.schema.xml
@@ -294,11 +294,6 @@
  <class name="TAMakerMichelElectronAlgorithm">
   <superclass name="TAAlgorithm"/>
   <attribute name="window_length" description="Window length (in ticks) for the ADC integral algorithm" type="u32" init-value="10000" is-not-null="yes"/>
-  <attribute name="trigger_on_adc" description="Whether to trigger on ADC integral" type="bool" init-value="false" is-not-null="yes"/>
-  <attribute name="trigger_on_n_channels" description="Whether to trigger on N Channels" type="bool" init-value="false" is-not-null="yes"/>
-  <attribute name="trigger_on_adjacency" description="Whether to trigger on adjacency" type="bool" init-value="false" is-not-null="yes"/>
-  <attribute name="adc_threshold" description="Threshold for the ADC integral algorithm" type="u32" init-value="10000" is-not-null="yes"/>
-  <attribute name="n_channels_threshold" description="Threshold for the N Channels algorithm" type="u32" init-value="8" is-not-null="yes"/>
   <attribute name="adjacency_threshold" description="Threshold for the adjacency algorithm" type="u32" init-value="6" is-not-null="yes"/>
   <attribute name="adjacency_tolerance" description="Tolerance for the number of allowed gaps for the adjacency algorithm" type="u32" init-value="4" is-not-null="yes"/>
  </class>
@@ -307,11 +302,7 @@
  <class name="TAMakerPlaneCoincidenceAlgorithm">
   <superclass name="TAAlgorithm"/>
   <attribute name="window_length" description="Window length (in ticks) for the ADC integral algorithm" type="u32" init-value="10000" is-not-null="yes"/>
-  <attribute name="trigger_on_adc" description="Whether to trigger on ADC integral" type="bool" init-value="false" is-not-null="yes"/>
-  <attribute name="trigger_on_n_channels" description="Whether to trigger on N Channels" type="bool" init-value="false" is-not-null="yes"/>
-  <attribute name="trigger_on_adjacency" description="Whether to trigger on adjacency" type="bool" init-value="false" is-not-null="yes"/>
   <attribute name="adc_threshold" description="Threshold for the ADC integral algorithm" type="u32" init-value="10000" is-not-null="yes"/>
-  <attribute name="n_channels_threshold" description="Threshold for the N Channels algorithm" type="u32" init-value="8" is-not-null="yes"/>
   <attribute name="adjacency_threshold" description="Threshold for the adjacency algorithm" type="u32" init-value="6" is-not-null="yes"/>
   <attribute name="adjacency_tolerance" description="Tolerance for the number of allowed gaps for the adjacency algorithm" type="u32" init-value="4" is-not-null="yes"/>
  </class>

--- a/schema/appmodel/trigger.schema.xml
+++ b/schema/appmodel/trigger.schema.xml
@@ -336,7 +336,7 @@
   <superclass name="TCAlgorithm"/>
  </class>
 
- <clsss name="TCMakerBundleNAlgorithm">
+ <class name="TCMakerBundleNAlgorithm">
   <superclass name="TCAlgorithm"/>
   <attribute name="bundle_size" description="Size of the bundle, in number of TAs" type="u32" init-value="1" is-not-null="yes"/>
  </class>

--- a/schema/appmodel/trigger.schema.xml
+++ b/schema/appmodel/trigger.schema.xml
@@ -336,6 +336,48 @@
   <superclass name="TCAlgorithm"/>
  </class>
 
+ <clsss name="TCMakerBundleNAlgorithm">
+  <superclass name="TCAlgorithm"/>
+  <attribute name="bundle_size" description="Size of the bundle, in number of TAs" type="u32" init-value="1" is-not-null="yes"/>
+ </class>
+
+ <class name="TCMakerChannelAdjacencyAlgorithm">
+  <superclass name="TCAlgorithm"/>
+  <attribute name="window_length" description="Window length (in ticks) for the algorithm" type="u32" init-value="10000" is-not-null="yes"/>
+  <attribute name="trigger_on_adc" description="Whether to trigger on ADC integral" type="bool" init-value="false" is-not-null="yes"/>
+  <attribute name="trigger_on_n_channels" description="Whether to trigger on N Channels" type="bool" init-value="false" is-not-null="yes"/>
+  <attribute name="adc_threshold" description="Threshold for the ADC integral algorithm" type="u32" init-value="10000" is-not-null="yes"/>
+  <attribute name="n_channels_threshold" description="Threshold for the N Channels algorithm" type="u32" init-value="8" is-not-null="yes"/>
+ </class>
+
+ <class name="TCMakerChannelDistanceAlgorithm">
+  <superclass name="TCAlgorithm"/>
+  <attribute name="max_tp_count" description="Maximum number of TPs in the TC" type="u32" init-value="8" is-not-null="yes"/>
+ </class>
+
+ <class name="TCMakerDBSCANAlgorithm">
+  <superclass name="TCAlgorithm"/>
+  <attribute name="max_tp_count" description="Maximum number of TPs in the TC" type="u32" init-value="8" is-not-null="yes"/>
+ </class>
+
+ <class name="TCMakerMichelElectronAlgorithm">
+  <superclass name="TCAlgorithm"/>
+  <attribute name="window_length" description="Window length (in ticks) for the algorithm" type="u32" init-value="10000" is-not-null="yes"/>
+  <attribute name="trigger_on_adc" description="Whether to trigger on ADC integral" type="bool" init-value="false" is-not-null="yes"/>
+  <attribute name="trigger_on_n_channels" description="Whether to trigger on N Channels" type="bool" init-value="false" is-not-null="yes"/>
+  <attribute name="adc_threshold" description="Threshold for the ADC integral algorithm" type="u32" init-value="10000" is-not-null="yes"/>
+  <attribute name="n_channels_threshold" description="Threshold for the N Channels algorithm" type="u32" init-value="8" is-not-null="yes"/>
+ </class>
+
+ <class name="TCMakerPlaneCoincidenceAlgorithm">
+  <superclass name="TCAlgorithm"/>
+  <attribute name="window_length" description="Window length (in ticks) for the algorithm" type="u32" init-value="10000" is-not-null="yes"/>
+  <attribute name="trigger_on_adc" description="Whether to trigger on ADC integral" type="bool" init-value="false" is-not-null="yes"/>
+  <attribute name="trigger_on_n_channels" description="Whether to trigger on N Channels" type="bool" init-value="false" is-not-null="yes"/>
+  <attribute name="adc_threshold" description="Threshold for the ADC integral algorithm" type="u32" init-value="10000" is-not-null="yes"/>
+  <attribute name="n_channels_threshold" description="Threshold for the N Channels algorithm" type="u32" init-value="8" is-not-null="yes"/>
+ </class>
+
  <class name="TriggerDataHandlerModule">
   <superclass name="DataHandlerModule"/>
   <relationship name="enabled_source_ids" description="List of source IDs enabled in this session: used by trigger to define the readout window for trigger decisions." class-type="SourceIDConf" low-cc="zero" high-cc="many" is-composite="no" is-exclusive="no" is-dependent="no"/>


### PR DESCRIPTION
Porting trigger algorithms from v4 to v5.
Full description in  https://github.com/DUNE-DAQ/triggeralgs/pull/78.

Has to be merged together with https://github.com/DUNE-DAQ/triggeralgs/pull/78, https://github.com/DUNE-DAQ/trigger/pull/339, https://github.com/DUNE-DAQ/trgdataformats/pull/41 and https://github.com/DUNE-DAQ/fdreadoutlibs/pull/220.