### PR TITLE
Add New TPG Configs

### DIFF
--- a/config/appmodel/moduleconfs.data.xml
+++ b/config/appmodel/moduleconfs.data.xml
@@ -94,6 +94,7 @@
  <comment creation-time="20240305T162137" created-by="glehmann" created-on="np04-srv-024.cern.ch" author="Unknown" text="add delay"/>
  <comment creation-time="20240305T172822" created-by="glehmann" created-on="np04-srv-024.cern.ch" author="Unknown" text=" adjust TA prescaling&#xA;"/>
  <comment creation-time="20240307T133917" created-by="glehmann" created-on="np04-srv-024.cern.ch" author="Unknown" text="disable TPG"/>
+ <comment creation-time="20240822T070558" created-by="aoranday" created-on="np04-srv-031.cern.ch" author="aoranday" text="Add TPG SimpleThreshold."/>
 </comments>
 
 <obj class="ActionPlan" id="readout-start">
@@ -227,11 +228,11 @@
  <attr name="queue_sizes" type="u32" val="10000"/>
  <attr name="thread_names_prefix" type="string" val="postproc-"/>
  <attr name="mask_processing" type="bool" val="0"/>
- <attr name="max_ticks_tot" type="u32" val="10000"/>
- <attr name="tpg_enabled" type="bool" val="1"/>
- <attr name="algorithm" type="string" val="SimpleThreshold"/>
- <attr name="threshold" type="u16" val="1900"/>
  <attr name="channel_map" type="string" val="PD2HDChannelMap"/>
+ <rel name="processing_steps">
+  <ref class="AVXFrugalPedestalSubtractProcessor" id="tpg-pedsub-proc"/>
+  <ref class="AVXThresholdProcessor" id="tpg-threshold-proc"/>
+ </rel>
 </obj>
 
 <obj class="DataHandlerConf" id="def-link-handler">

--- a/schema/appmodel/application.schema.xml
+++ b/schema/appmodel/application.schema.xml
@@ -80,7 +80,7 @@
 
 <oks-schema>
 
-<info name="" type="" num-of-items="46" oks-format="schema" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20230616T091343" last-modified-by="aoranday" last-modified-on="np04-srv-024.cern.ch" last-modification-time="20240819T144357"/>
+<info name="" type="" num-of-items="46" oks-format="schema" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20230616T091343" last-modified-by="aoranday" last-modified-on="np04-srv-013.cern.ch" last-modification-time="20240820T063841"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>

--- a/schema/appmodel/application.schema.xml
+++ b/schema/appmodel/application.schema.xml
@@ -80,7 +80,7 @@
 
 <oks-schema>
 
-<info name="" type="" num-of-items="47" oks-format="schema" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20230616T091343" last-modified-by="thea" last-modified-on="np04-srv-031.cern.ch" last-modification-time="20240618T084639"/>
+<info name="" type="" num-of-items="46" oks-format="schema" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20230616T091343" last-modified-by="aoranday" last-modified-on="np04-srv-024.cern.ch" last-modification-time="20240819T144357"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
@@ -323,16 +323,6 @@
   <attribute name="queue_type" description="Type of queue" type="enum" range="kUnknown,kStdDeQueue,kFollySPSCQueue,kFollyMPMCQueue" init-value="kFollySPSCQueue" is-not-null="yes"/>
   <attribute name="capacity" type="u32" init-value="100" is-not-null="yes"/>
   <attribute name="data_type" description="string identifying type of data transferred through this queue" type="string" is-not-null="yes"/>
- </class>
-
- <class name="RawDataProcessor">
-  <superclass name="DataProcessor"/>
-  <attribute name="max_ticks_tot" description="Max ToT after which ongoing TPs are discarded, default is 8000" type="u32" init-value="8000" is-not-null="yes"/>
-  <attribute name="tpg_enabled" type="bool" init-value="true"/>
-  <attribute name="algorithm" description="TP generation algorithm" type="string"/>
-  <attribute name="threshold" description="Hit detection threshold" type="u16"/>
-  <attribute name="channel_mask" description="List of channels to be masked from TP generation" type="u32" is-multi-value="yes"/>
-  <attribute name="channel_map" type="string"/>
  </class>
 
  <class name="ReadoutApplication">

--- a/schema/appmodel/trigger.schema.xml
+++ b/schema/appmodel/trigger.schema.xml
@@ -80,7 +80,7 @@
 
 <oks-schema>
 
-<info name="" type="" num-of-items="37" oks-format="schema" oks-version="862f2957270" created-by="asztuc" created-on="np04-srv-019.cern.ch" creation-time="20231211T133151" last-modified-by="aoranday" last-modified-on="np04-srv-024.cern.ch" last-modification-time="20240819T144357"/>
+<info name="" type="" num-of-items="37" oks-format="schema" oks-version="862f2957270" created-by="asztuc" created-on="np04-srv-019.cern.ch" creation-time="20231211T133151" last-modified-by="aoranday" last-modified-on="np04-srv-013.cern.ch" last-modification-time="20240820T063841"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
@@ -89,7 +89,13 @@
 
 
  <class name="AVXAbsRunSumProcessor" description="TPG absolute running sum signal processor. Outputs a scaled running sum from the absolute value of the input signal.">
-  <superclass name="AVXRunSumProcessor"/>
+  <superclass name="ProcessingStep"/>
+  <attribute name="memory_factor_plane0" description="Absolute running sum memory factor for plane 0." type="u8" range="0..10" init-value="8" is-not-null="yes"/>
+  <attribute name="memory_factor_plane1" description="Absolute running sum memory factor for plane 1." type="u8" range="0..10" init-value="8" is-not-null="yes"/>
+  <attribute name="memory_factor_plane2" description="Absolute running sum memory factor for plane 2." type="u8" range="0..10" init-value="8" is-not-null="yes"/>
+  <attribute name="scale_factor_plane0" description="Absolute running sum scale factor for plane 0." type="u8" range="1..10" init-value="5" is-not-null="yes"/>
+  <attribute name="scale_factor_plane1" description="Absolute running sum scale factor for plane 1." type="u8" range="1..10" init-value="5" is-not-null="yes"/>
+  <attribute name="scale_factor_plane2" description="Absolute running sum scale factor for plane 2." type="u8" range="1..10" init-value="5" is-not-null="yes"/>
  </class>
 
  <class name="AVXFrugalPedestalSubtractProcessor" description="TPG frugal pedestal subtraction signal processor. Frugally updates the pedestal estimation and outputs the difference with the input signal.">

--- a/schema/appmodel/trigger.schema.xml
+++ b/schema/appmodel/trigger.schema.xml
@@ -89,13 +89,7 @@
 
 
  <class name="AVXAbsRunSumProcessor" description="TPG absolute running sum signal processor. Outputs a scaled running sum from the absolute value of the input signal.">
-  <superclass name="ProcessingStep"/>
-  <attribute name="memory_factor_plane0" description="Absolute running sum memory factor for plane 0." type="u8" range="0..10" init-value="8" is-not-null="yes"/>
-  <attribute name="memory_factor_plane1" description="Absolute running sum memory factor for plane 1." type="u8" range="0..10" init-value="8" is-not-null="yes"/>
-  <attribute name="memory_factor_plane2" description="Absolute running sum memory factor for plane 2." type="u8" range="0..10" init-value="8" is-not-null="yes"/>
-  <attribute name="scale_factor_plane0" description="Absolute running sum scale factor for plane 0." type="u8" range="1..10" init-value="5" is-not-null="yes"/>
-  <attribute name="scale_factor_plane1" description="Absolute running sum scale factor for plane 1." type="u8" range="1..10" init-value="5" is-not-null="yes"/>
-  <attribute name="scale_factor_plane2" description="Absolute running sum scale factor for plane 2." type="u8" range="1..10" init-value="5" is-not-null="yes"/>
+  <superclass name="AVXRunSumProcessor"/>
  </class>
 
  <class name="AVXFrugalPedestalSubtractProcessor" description="TPG frugal pedestal subtraction signal processor. Frugally updates the pedestal estimation and outputs the difference with the input signal.">
@@ -105,19 +99,19 @@
 
  <class name="AVXRunSumProcessor" description="TPG running sum signal processor. Outputs a scaled running sum from the input signal.">
   <superclass name="ProcessingStep"/>
-  <attribute name="memory_factor_plane0" description="Running sum memory factor for plane 0." type="u8" range="0..10" init-value="8" is-not-null="yes"/>
-  <attribute name="memory_factor_plane1" description="Running sum memory factor for plane 1." type="u8" range="0..10" init-value="8" is-not-null="yes"/>
-  <attribute name="memory_factor_plane2" description="Running sum memory factor for plane 2." type="u8" range="0..10" init-value="8" is-not-null="yes"/>
-  <attribute name="scale_factor_plane0" description="Running sum scale factor for plane 0." type="u8" range="1..10" init-value="10" is-not-null="yes"/>
-  <attribute name="scale_factor_plane1" description="Running sum scale factor for plane 1." type="u8" range="1..10" init-value="10" is-not-null="yes"/>
-  <attribute name="scale_factor_plane2" description="Running sum scale factor for plane 2." type="u8" range="1..10" init-value="10" is-not-null="yes"/>
+  <attribute name="memory_factor_plane0" description="Running sum memory factor for plane 0. Gets divided by 10." type="u8" range="0..10" init-value="8" is-not-null="yes"/>
+  <attribute name="memory_factor_plane1" description="Running sum memory factor for plane 1. Gets divided by 10." type="u8" range="0..10" init-value="8" is-not-null="yes"/>
+  <attribute name="memory_factor_plane2" description="Running sum memory factor for plane 2. Gets divided by 10." type="u8" range="0..10" init-value="8" is-not-null="yes"/>
+  <attribute name="scale_factor_plane0" description="Running sum scale factor for plane 0. Gets divided by 10." type="u8" range="1..10" init-value="10" is-not-null="yes"/>
+  <attribute name="scale_factor_plane1" description="Running sum scale factor for plane 1. Gets divided by 10." type="u8" range="1..10" init-value="10" is-not-null="yes"/>
+  <attribute name="scale_factor_plane2" description="Running sum scale factor for plane 2. Gets divided by 10." type="u8" range="1..10" init-value="10" is-not-null="yes"/>
  </class>
 
  <class name="AVXThresholdProcessor" description="TPG threshold signal processor. Filters the input signal by passing values that are above threshold and suppresing otherwise.">
   <superclass name="ProcessingStep"/>
-  <attribute name="plane0" description="Threshold for plane 0." type="u8" init-value="100" is-not-null="yes"/>
-  <attribute name="plane1" description="Threshold for plane 1." type="u8" init-value="100" is-not-null="yes"/>
-  <attribute name="plane2" description="Threshold for plane 2." type="u8" init-value="100" is-not-null="yes"/>
+  <attribute name="plane0" description="Threshold for plane 0." type="u16" init-value="100" is-not-null="yes"/>
+  <attribute name="plane1" description="Threshold for plane 1." type="u16" init-value="100" is-not-null="yes"/>
+  <attribute name="plane2" description="Threshold for plane 2." type="u16" init-value="100" is-not-null="yes"/>
  </class>
 
  <class name="CustomTCMaker">

--- a/schema/appmodel/trigger.schema.xml
+++ b/schema/appmodel/trigger.schema.xml
@@ -80,13 +80,39 @@
 
 <oks-schema>
 
-<info name="" type="" num-of-items="29" oks-format="schema" oks-version="oks-08-03-04-11-g3f5bde7 built &quot;Feb 21 2023&quot;" created-by="asztuc" created-on="np04-srv-019.cern.ch" creation-time="20231211T133151" last-modified-by="glehmann" last-modified-on="np04-srv-019.cern.ch" last-modification-time="20240402T091944"/>
+<info name="" type="" num-of-items="37" oks-format="schema" oks-version="862f2957270" created-by="asztuc" created-on="np04-srv-019.cern.ch" creation-time="20231211T133151" last-modified-by="aoranday" last-modified-on="np04-srv-024.cern.ch" last-modification-time="20240819T144357"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
  <file path="schema/appmodel/application.schema.xml"/>
 </include>
 
+
+ <class name="AVXAbsRunSumProcessor" description="TPG absolute running sum signal processor. Outputs a scaled running sum from the absolute value of the input signal.">
+  <superclass name="AVXRunSumProcessor"/>
+ </class>
+
+ <class name="AVXFrugalPedestalSubtractProcessor" description="TPG frugal pedestal subtraction signal processor. Frugally updates the pedestal estimation and outputs the difference with the input signal.">
+  <superclass name="ProcessingStep"/>
+  <attribute name="accum_limit" description="Accumulation limit to increment/decrement the estimated pedestal value." type="u8" init-value="10" is-not-null="yes"/>
+ </class>
+
+ <class name="AVXRunSumProcessor" description="TPG running sum signal processor. Outputs a scaled running sum from the input signal.">
+  <superclass name="ProcessingStep"/>
+  <attribute name="memory_factor_plane0" description="Running sum memory factor for plane 0." type="u8" range="0..10" init-value="8" is-not-null="yes"/>
+  <attribute name="memory_factor_plane1" description="Running sum memory factor for plane 1." type="u8" range="0..10" init-value="8" is-not-null="yes"/>
+  <attribute name="memory_factor_plane2" description="Running sum memory factor for plane 2." type="u8" range="0..10" init-value="8" is-not-null="yes"/>
+  <attribute name="scale_factor_plane0" description="Running sum scale factor for plane 0." type="u8" range="1..10" init-value="10" is-not-null="yes"/>
+  <attribute name="scale_factor_plane1" description="Running sum scale factor for plane 1." type="u8" range="1..10" init-value="10" is-not-null="yes"/>
+  <attribute name="scale_factor_plane2" description="Running sum scale factor for plane 2." type="u8" range="1..10" init-value="10" is-not-null="yes"/>
+ </class>
+
+ <class name="AVXThresholdProcessor" description="TPG threshold signal processor. Filters the input signal by passing values that are above threshold and suppresing otherwise.">
+  <superclass name="ProcessingStep"/>
+  <attribute name="plane0" description="Threshold for plane 0." type="u8" init-value="100" is-not-null="yes"/>
+  <attribute name="plane1" description="Threshold for plane 1." type="u8" init-value="100" is-not-null="yes"/>
+  <attribute name="plane2" description="Threshold for plane 2." type="u8" init-value="100" is-not-null="yes"/>
+ </class>
 
  <class name="CustomTCMaker">
   <superclass name="StandaloneTCMakerModule"/>
@@ -137,11 +163,6 @@
   </method>
  </class>
 
- <class name="MLTModule">
-  <superclass name="DaqModule"/>
-  <relationship name="configuration" class-type="MLTConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
- </class>
-
  <class name="MLTConf">
   <attribute name="template_for" type="class" init-value="MLTModule"/>
   <attribute name="td_out_of_timeout" type="bool" init-value="true" is-not-null="yes"/>
@@ -149,16 +170,20 @@
   <attribute name="td_readout_limit" type="u32" init-value="1000" is-not-null="yes"/>
  </class>
 
+ <class name="MLTModule">
+  <superclass name="DaqModule"/>
+  <relationship name="configuration" class-type="MLTConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
+ </class>
+
+ <class name="ProcessingStep" description="Base class for TPG processors.">
+  <superclass name="Jsonable"/>
+ </class>
+
  <class name="ROIGroupConf">
   <attribute name="number_of_link_groups" type="u32" init-value="1" is-not-null="yes"/>
   <attribute name="probability" type="float" init-value="0.1" is-not-null="yes"/>
   <attribute name="time_window" type="u32" init-value="1" is-not-null="yes"/>
   <attribute name="groups_selection_mode" type="enum" range="kRandom,kSequential" init-value="kRandom" is-not-null="yes"/>
- </class>
-
- <class name="RandomTCMakerModule">
-  <superclass name="StandaloneTCMakerModule"/>
-  <relationship name="configuration" class-type="RandomTCMakerConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
  </class>
 
  <class name="RandomTCMakerConf">
@@ -169,13 +194,25 @@
   <attribute name="time_distribution" type="enum" range="kUniform,kPoisson" init-value="kUniform" is-not-null="yes"/>
  </class>
 
- <class name="StandaloneTCMakerModule">
-  <superclass name="DaqModule"/>
+ <class name="RandomTCMakerModule">
+  <superclass name="StandaloneTCMakerModule"/>
+  <relationship name="configuration" class-type="RandomTCMakerConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
+ </class>
+
+ <class name="RawDataProcessor">
+  <superclass name="DataProcessor"/>
+  <attribute name="channel_mask" description="List of channels to be masked from TP generation" type="u32" is-multi-value="yes"/>
+  <attribute name="channel_map" type="string"/>
+  <relationship name="processing_steps" class-type="ProcessingStep" low-cc="one" high-cc="many" is-composite="no" is-exclusive="no" is-dependent="no"/>
  </class>
 
  <class name="StandaloneTCMakerConf" is-abstract="yes">
   <attribute name="template_for" type="class" init-value="StandaloneTCMakerModule" is-not-null="yes"/>
   <attribute name="timestamp_method" type="enum" range="kTimeSync,kSystemClock" init-value="kTimeSync" is-not-null="yes"/>
+ </class>
+
+ <class name="StandaloneTCMakerModule">
+  <superclass name="DaqModule"/>
  </class>
 
  <class name="TAAlgorithm" description="Base class for TA algorithms">
@@ -188,6 +225,27 @@
   <superclass name="DataProcessor"/>
   <attribute name="print_ta_info" description="Whether to print TP information in the TA processor" type="bool" init-value="false"/>
   <relationship name="algorithms" class-type="TCAlgorithm" low-cc="one" high-cc="many" is-composite="no" is-exclusive="no" is-dependent="no"/>
+ </class>
+
+ <class name="TAMakerADCSimpleWindowAlgorithm">
+  <superclass name="TAAlgorithm"/>
+  <attribute name="adc_threshold" description="Threshold for the ADC integral algorithm" type="u32" init-value="10000" is-not-null="yes"/>
+  <attribute name="window_length" description="Window length (in ticks) for the ADC integral algorithm" type="u32" init-value="10000" is-not-null="yes"/>
+ </class>
+
+ <class name="TAMakerHorizontalMuonAlgorithm">
+  <superclass name="TAAlgorithm"/>
+  <attribute name="trigger_on_adc" description="Whether to trigger on ADC integral" type="bool" init-value="false" is-not-null="yes"/>
+  <attribute name="trigger_on_n_channels" description="Whether to trigger on N Channels" type="bool" init-value="false" is-not-null="yes"/>
+  <attribute name="trigger_on_adjacency" description="Whether to trigger on adjacency" type="bool" init-value="false" is-not-null="yes"/>
+  <attribute name="adc_threshold" description="Threshold for the ADC integral algorithm" type="u32" init-value="10000" is-not-null="yes"/>
+  <attribute name="n_channels_threshold" description="Threshold for the N Channels algorithm" type="u32" init-value="8" is-not-null="yes"/>
+  <attribute name="adjacency_threshold" description="Threshold for the adjacency algorithm" type="u32" init-value="6" is-not-null="yes"/>
+  <attribute name="adjacency_tolerance" description="Tolerance for the number of allowed gaps for the adjacency algorithm" type="u32" init-value="4" is-not-null="yes"/>
+ </class>
+
+ <class name="TAMakerPrescaleAlgorithm">
+  <superclass name="TAAlgorithm"/>
  </class>
 
  <class name="TCAlgorithm" description="Base class for TC algorithms">
@@ -219,6 +277,23 @@
   <relationship name="mandatory_links" class-type="SourceIDConf" low-cc="zero" high-cc="many" is-composite="no" is-exclusive="no" is-dependent="no"/>
  </class>
 
+ <class name="TCMakerADCSimpleWindowAlgorithm">
+  <superclass name="TCAlgorithm"/>
+ </class>
+
+ <class name="TCMakerHorizontalMuonAlgorithm">
+  <superclass name="TCAlgorithm"/>
+  <attribute name="trigger_on_adc" description="Whether to trigger on ADC integral" type="bool" init-value="false" is-not-null="yes"/>
+  <attribute name="trigger_on_n_channels" description="Whether to trigger on N Channels" type="bool" init-value="false" is-not-null="yes"/>
+  <attribute name="trigger_on_adjacency" description="Whether to trigger on adjacency" type="bool" init-value="false" is-not-null="yes"/>
+  <attribute name="adc_threshold" description="Threshold for the ADC integral algorithm" type="u32" init-value="10000" is-not-null="yes"/>
+  <attribute name="n_channels_threshold" description="Threshold for the N Channels algorithm" type="u32" init-value="8" is-not-null="yes"/>
+ </class>
+
+ <class name="TCMakerPrescaleAlgorithm">
+  <superclass name="TCAlgorithm"/>
+ </class>
+
  <class name="TCReadoutMap">
   <attribute name="candidate_type" type="u32" init-value="0" is-not-null="yes"/>
   <attribute name="time_before" type="u32" init-value="1000" is-not-null="yes"/>
@@ -244,27 +319,6 @@
   <attribute name="time_after" type="u32" init-value="20000" is-not-null="yes"/>
  </class>
 
- <class name="TAMakerADCSimpleWindowAlgorithm">
-  <superclass name="TAAlgorithm"/>
-  <attribute name="adc_threshold" description="Threshold for the ADC integral algorithm" type="u32" init-value="10000" is-not-null="yes"/>
-  <attribute name="window_length" description="Window length (in ticks) for the ADC integral algorithm" type="u32" init-value="10000" is-not-null="yes"/>
- </class>
-
- <class name="TAMakerHorizontalMuonAlgorithm">
-  <superclass name="TAAlgorithm"/>
-  <attribute name="trigger_on_adc" description="Whether to trigger on ADC integral" type="bool" init-value="false" is-not-null="yes"/>
-  <attribute name="trigger_on_n_channels" description="Whether to trigger on N Channels" type="bool" init-value="false" is-not-null="yes"/>
-  <attribute name="trigger_on_adjacency" description="Whether to trigger on adjacency" type="bool" init-value="false" is-not-null="yes"/>
-  <attribute name="adc_threshold" description="Threshold for the ADC integral algorithm" type="u32" init-value="10000" is-not-null="yes"/>
-  <attribute name="n_channels_threshold" description="Threshold for the N Channels algorithm" type="u32" init-value="8" is-not-null="yes"/>
-  <attribute name="adjacency_threshold" description="Threshold for the adjacency algorithm" type="u32" init-value="6" is-not-null="yes"/>
-  <attribute name="adjacency_tolerance" description="Tolerance for the number of allowed gaps for the adjacency algorithm" type="u32" init-value="4" is-not-null="yes"/>
- </class>
-
- <class name="TAMakerPrescaleAlgorithm">
-  <superclass name="TAAlgorithm"/>
- </class>
-
  <class name="TriggerApplication">
   <superclass name="ResourceSetAND"/>
   <superclass name="SmartDaqApplication"/>
@@ -274,24 +328,6 @@
   <method name="generate_modules" description="Generate daq module dal objects for streams of thie TriggerApplication on the fly">
    <method-implementation language="c++" prototype="std::vector&lt;const dunedaq::confmodel::DaqModule*&gt; generate_modules(conffwk::Configuration*, const std::string&amp;, const confmodel::Session*) const override" body=""/>
   </method>
- </class>
-
- 
- <class name="TCMakerADCSimpleWindowAlgorithm">
-  <superclass name="TCAlgorithm"/>
- </class>
-
- <class name="TCMakerHorizontalMuonAlgorithm">
-  <superclass name="TCAlgorithm"/>
-  <attribute name="trigger_on_adc" description="Whether to trigger on ADC integral" type="bool" init-value="false" is-not-null="yes"/>
-  <attribute name="trigger_on_n_channels" description="Whether to trigger on N Channels" type="bool" init-value="false" is-not-null="yes"/>
-  <attribute name="trigger_on_adjacency" description="Whether to trigger on adjacency" type="bool" init-value="false" is-not-null="yes"/>
-  <attribute name="adc_threshold" description="Threshold for the ADC integral algorithm" type="u32" init-value="10000" is-not-null="yes"/>
-  <attribute name="n_channels_threshold" description="Threshold for the N Channels algorithm" type="u32" init-value="8" is-not-null="yes"/>
- </class>
-
- <class name="TCMakerPrescaleAlgorithm">
-  <superclass name="TCAlgorithm"/>
  </class>
 
  <class name="TriggerDataHandlerModule">

--- a/test/config/ru-segment.data.xml
+++ b/test/config/ru-segment.data.xml
@@ -63,7 +63,7 @@
 
 <oks-data>
 
-<info name="" type="" num-of-items="10" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T105615" last-modified-by="thea" last-modified-on="np04-srv-031.cern.ch" last-modification-time="20240628T062322"/>
+<info name="" type="" num-of-items="12" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T105615" last-modified-by="aoranday" last-modified-on="np04-srv-031.cern.ch" last-modification-time="20240829T102857"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
@@ -94,8 +94,33 @@
  <comment creation-time="20240612T203623" created-by="thea" created-on="np04-srv-031.cern.ch" author="thea" text="adding dummy connections to ru-02"/>
  <comment creation-time="20240620T161416" created-by="gjc" created-on="latitude" author="gjc" text="l"/>
  <comment creation-time="20240628T062322" created-by="thea" created-on="np04-srv-031.cern.ch" author="thea" text="removing broadcasters from control apps"/>
+ <comment creation-time="20240822T070558" created-by="aoranday" created-on="np04-srv-031.cern.ch" author="aoranday" text="Add TPG SimpleThreshold."/>
+ <comment creation-time="20240828T140226" created-by="aoranday" created-on="np04-srv-031.cern.ch" author="aoranday" text="Change AbsRS config."/>
+ <comment creation-time="20240829T102857" created-by="aoranday" created-on="np04-srv-031.cern.ch" author="aoranday" text="Add AbsRS processor."/>
 </comments>
 
+
+<obj class="AVXFrugalPedestalSubtractProcessor" id="tpg-pedsub-proc">
+ <attr name="accum_limit" type="u8" val="10"/>
+</obj>
+
+<obj class="AVXAbsRunSumProcessor" id="tpg-absrs-proc">
+ <attr name="memory_factor_plane0" type="u8" val="8"/>
+ <attr name="memory_factor_plane1" type="u8" val="8"/>
+ <attr name="memory_factor_plane2" type="u8" val="8"/>
+ <attr name="scale_factor_plane0" type="u8" val="10"/>
+ <attr name="scale_factor_plane1" type="u8" val="10"/>
+ <attr name="scale_factor_plane2" type="u8" val="10"/>
+</obj>
+
+<obj class="AVXRunSumProcessor" id="tpg-rs-proc">
+ <attr name="memory_factor_plane0" type="u8" val="8"/>
+ <attr name="memory_factor_plane1" type="u8" val="8"/>
+ <attr name="memory_factor_plane2" type="u8" val="8"/>
+ <attr name="scale_factor_plane0" type="u8" val="10"/>
+ <attr name="scale_factor_plane1" type="u8" val="10"/>
+ <attr name="scale_factor_plane2" type="u8" val="10"/>
+</obj>
 
 <obj class="RCApplication" id="ru-controller">
  <attr name="application_name" type="string" val="drunc-controller"/>


### PR DESCRIPTION
These are the new configuration objects to be used the modular TPG design. Testing requires PRs in `fdreadoutlibs` and `tpglibs` with details in the associated `fdreadoutlibs` PR.

There is in issue in creating a new object when it is the first one in the class list https://github.com/DUNE-DAQ/dbe/issues/31. This may affect any testing for that creates new `AVXAbsRunSumProcessor` objects.

### Associated PRs
* https://github.com/DUNE-DAQ/fdreadoutlibs/pull/221
* https://github.com/DUNE-DAQ/tpglibs/pull/3