### PR TITLE
Correct location for OpMon objects

### DIFF
--- a/config/appmodel/opmon.data.xml
+++ b/config/appmodel/opmon.data.xml
@@ -66,7 +66,7 @@
 <info name="" type="" num-of-items="2" oks-format="data" oks-version="862f2957270" created-by="maroda" created-on="np04-srv-015.cern.ch" creation-time="20240916T090345" last-modified-by="maroda" last-modified-on="np04-srv-015.cern.ch" last-modification-time="20240916T091157"/>
 
 <include>
- <file path="/nfs/home/maroda/DAQ/OpMonTest/sourcecode/confmodel/schema/confmodel/dunedaq.schema.xml"/>
+ <file path="schema/confmodel/dunedaq.schema.xml"/>
 </include>
 
 <comments>

--- a/config/appmodel/opmon.data.xml
+++ b/config/appmodel/opmon.data.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="ASCII"?>
+
+<!-- oks-data version 2.2 -->
+
+
+<!DOCTYPE oks-data [
+  <!ELEMENT oks-data (info, (include)?, (comments)?, (obj)+)>
+  <!ELEMENT info EMPTY>
+  <!ATTLIST info
+      name CDATA #IMPLIED
+      type CDATA #IMPLIED
+      num-of-items CDATA #REQUIRED
+      oks-format CDATA #FIXED "data"
+      oks-version CDATA #REQUIRED
+      created-by CDATA #IMPLIED
+      created-on CDATA #IMPLIED
+      creation-time CDATA #IMPLIED
+      last-modified-by CDATA #IMPLIED
+      last-modified-on CDATA #IMPLIED
+      last-modification-time CDATA #IMPLIED
+  >
+  <!ELEMENT include (file)*>
+  <!ELEMENT file EMPTY>
+  <!ATTLIST file
+      path CDATA #REQUIRED
+  >
+  <!ELEMENT comments (comment)*>
+  <!ELEMENT comment EMPTY>
+  <!ATTLIST comment
+      creation-time CDATA #REQUIRED
+      created-by CDATA #REQUIRED
+      created-on CDATA #REQUIRED
+      author CDATA #REQUIRED
+      text CDATA #REQUIRED
+  >
+  <!ELEMENT obj (attr | rel)*>
+  <!ATTLIST obj
+      class CDATA #REQUIRED
+      id CDATA #REQUIRED
+  >
+  <!ELEMENT attr (data)*>
+  <!ATTLIST attr
+      name CDATA #REQUIRED
+      type (bool|s8|u8|s16|u16|s32|u32|s64|u64|float|double|date|time|string|uid|enum|class|-) "-"
+      val CDATA ""
+  >
+  <!ELEMENT data EMPTY>
+  <!ATTLIST data
+      val CDATA #REQUIRED
+  >
+  <!ELEMENT rel (ref)*>
+  <!ATTLIST rel
+      name CDATA #REQUIRED
+      class CDATA ""
+      id CDATA ""
+  >
+  <!ELEMENT ref EMPTY>
+  <!ATTLIST ref
+      class CDATA #REQUIRED
+      id CDATA #REQUIRED
+  >
+]>
+
+<oks-data>
+
+<info name="" type="" num-of-items="2" oks-format="data" oks-version="862f2957270" created-by="maroda" created-on="np04-srv-015.cern.ch" creation-time="20240916T090345" last-modified-by="maroda" last-modified-on="np04-srv-015.cern.ch" last-modification-time="20240916T091157"/>
+
+<include>
+ <file path="/nfs/home/maroda/DAQ/OpMonTest/sourcecode/confmodel/schema/confmodel/dunedaq.schema.xml"/>
+</include>
+
+<comments>
+ <comment creation-time="20240916T091157" created-by="maroda" created-on="np04-srv-015.cern.ch" author="maroda" text="Add minimum opmon confs"/>
+</comments>
+
+
+<obj class="OpMonConf" id="fast-all-monitoring">
+ <attr name="level" type="u32" val="4294967295"/>
+ <attr name="interval_s" type="u32" val="2"/>
+</obj>
+
+<obj class="OpMonConf" id="slow-all-monitoring">
+ <attr name="level" type="u32" val="4294967295"/>
+ <attr name="interval_s" type="u32" val="10"/>
+</obj>
+
+</oks-data>

--- a/config/appmodel/opmon.data.xml
+++ b/config/appmodel/opmon.data.xml
@@ -63,7 +63,7 @@
 
 <oks-data>
 
-<info name="" type="" num-of-items="2" oks-format="data" oks-version="862f2957270" created-by="maroda" created-on="np04-srv-015.cern.ch" creation-time="20240916T090345" last-modified-by="maroda" last-modified-on="np04-srv-015.cern.ch" last-modification-time="20240916T091157"/>
+<info name="" type="" num-of-items="4" oks-format="data" oks-version="862f2957270" created-by="maroda" created-on="np04-srv-015.cern.ch" creation-time="20240916T090345" last-modified-by="maroda" last-modified-on="np04-srv-015.cern.ch" last-modification-time="20240916T113721"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
@@ -71,6 +71,7 @@
 
 <comments>
  <comment creation-time="20240916T091157" created-by="maroda" created-on="np04-srv-015.cern.ch" author="maroda" text="Add minimum opmon confs"/>
+ <comment creation-time="20240916T113721" created-by="maroda" created-on="np04-srv-015.cern.ch" author="maroda" text="add opmon URIs"/>
 </comments>
 
 
@@ -82,6 +83,16 @@
 <obj class="OpMonConf" id="slow-all-monitoring">
  <attr name="level" type="u32" val="4294967295"/>
  <attr name="interval_s" type="u32" val="10"/>
+</obj>
+
+<obj class="OpMonURI" id="cern-opmon-uri">
+ <attr name="path" type="string" val="monkafka.cern.ch:30092/opmon_stream"/>
+ <attr name="type" type="enum" val="stream"/>
+</obj>
+
+<obj class="OpMonURI" id="local-opmon-uri">
+ <attr name="path" type="string" val="./info.json"/>
+ <attr name="type" type="enum" val="file"/>
 </obj>
 
 </oks-data>

--- a/test/config/df-segment.data.xml
+++ b/test/config/df-segment.data.xml
@@ -63,13 +63,14 @@
 
 <oks-data>
 
-<info name="" type="" num-of-items="23" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T105629" last-modified-by="maroda" last-modified-on="np04-srv-015.cern.ch" last-modification-time="20240912T143615"/>
+<info name="" type="" num-of-items="23" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T105629" last-modified-by="maroda" last-modified-on="np04-srv-015.cern.ch" last-modification-time="20240916T092524"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
  <file path="schema/appmodel/application.schema.xml"/>
  <file path="config/appmodel/connections.data.xml"/>
  <file path="config/appmodel/moduleconfs.data.xml"/>
+ <file path="config/appmodel/opmon.data.xml"/>
  <file path="test/config/hosts.data.xml"/>
 </include>
 
@@ -89,6 +90,8 @@
  <comment creation-time="20240617T203421" created-by="thea" created-on="np04-srv-031.cern.ch" author="thea" text="adding datawriters"/>
  <comment creation-time="20240628T062322" created-by="thea" created-on="np04-srv-031.cern.ch" author="thea" text="removing broadcasters from control apps"/>
  <comment creation-time="20240912T143615" created-by="maroda" created-on="np04-srv-015.cern.ch" author="maroda" text="add opmon objects"/>
+ <comment creation-time="20240916T091035" created-by="maroda" created-on="np04-srv-015.cern.ch" author="maroda" text="change monitoring object"/>
+ <comment creation-time="20240916T092524" created-by="maroda" created-on="np04-srv-015.cern.ch" author="maroda" text="Correct locations for OpMonConf objects"/>
 </comments>
 
 

--- a/test/config/hsi-segment.data.xml
+++ b/test/config/hsi-segment.data.xml
@@ -63,7 +63,7 @@
 
 <oks-data>
 
-<info name="" type="" num-of-items="14" oks-format="data" oks-version="862f2957270" created-by="asztuc" created-on="np04-srv-019.cern.ch" creation-time="20231212T171111" last-modified-by="maroda" last-modified-on="np04-srv-015.cern.ch" last-modification-time="20240912T143615"/>
+<info name="" type="" num-of-items="14" oks-format="data" oks-version="862f2957270" created-by="asztuc" created-on="np04-srv-019.cern.ch" creation-time="20231212T171111" last-modified-by="maroda" last-modified-on="np04-srv-015.cern.ch" last-modification-time="20240916T092524"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
@@ -71,6 +71,7 @@
  <file path="schema/appmodel/trigger.schema.xml"/>
  <file path="config/appmodel/connections.data.xml"/>
  <file path="config/appmodel/moduleconfs.data.xml"/>
+ <file path="config/appmodel/opmon.data.xml"/>
  <file path="test/config/hosts.data.xml"/>
 </include>
 
@@ -83,6 +84,8 @@
  <comment creation-time="20240325T124934" created-by="glehmann" created-on="np04-srv-019.cern.ch" author="Unknown" text="adjusted to name changes in connections"/>
  <comment creation-time="20240628T062322" created-by="thea" created-on="np04-srv-031.cern.ch" author="thea" text="removing broadcasters from control apps"/>
  <comment creation-time="20240912T143615" created-by="maroda" created-on="np04-srv-015.cern.ch" author="maroda" text="add opmon objects"/>
+ <comment creation-time="20240916T091035" created-by="maroda" created-on="np04-srv-015.cern.ch" author="maroda" text="change monitoring object"/>
+ <comment creation-time="20240916T092524" created-by="maroda" created-on="np04-srv-015.cern.ch" author="maroda" text="Correct locations for OpMonConf objects"/>
 </comments>
 
 

--- a/test/config/ru-segment.data.xml
+++ b/test/config/ru-segment.data.xml
@@ -63,7 +63,7 @@
 
 <oks-data>
 
-<info name="" type="" num-of-items="40" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T105615" last-modified-by="maroda" last-modified-on="np04-srv-015.cern.ch" last-modification-time="20240912T143615"/>
+<info name="" type="" num-of-items="40" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T105615" last-modified-by="maroda" last-modified-on="np04-srv-015.cern.ch" last-modification-time="20240916T092524"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
@@ -72,6 +72,7 @@
  <file path="schema/appmodel/wiec.schema.xml"/>
  <file path="config/appmodel/connections.data.xml"/>
  <file path="config/appmodel/moduleconfs.data.xml"/>
+ <file path="config/appmodel/opmon.data.xml"/>
  <file path="test/config/hosts.data.xml"/>
 </include>
 
@@ -99,6 +100,8 @@
  <comment creation-time="20240828T140226" created-by="aoranday" created-on="np04-srv-031.cern.ch" author="aoranday" text="Change AbsRS config."/>
  <comment creation-time="20240829T102857" created-by="aoranday" created-on="np04-srv-031.cern.ch" author="aoranday" text="Add AbsRS processor."/>
  <comment creation-time="20240912T143615" created-by="maroda" created-on="np04-srv-015.cern.ch" author="maroda" text="add opmon objects"/>
+ <comment creation-time="20240916T091035" created-by="maroda" created-on="np04-srv-015.cern.ch" author="maroda" text="change monitoring object"/>
+ <comment creation-time="20240916T092524" created-by="maroda" created-on="np04-srv-015.cern.ch" author="maroda" text="Correct locations for OpMonConf objects"/>
 </comments>
 
 

--- a/test/config/test-session.data.xml
+++ b/test/config/test-session.data.xml
@@ -141,16 +141,6 @@
  <attr name="op_env" type="string" val="test"/>
 </obj>
 
-<obj class="OpMonURI" id="cern-opmon-uri">
- <attr name="path" type="string" val="monkafka.cern.ch:30092/opmon_stream"/>
- <attr name="type" type="enum" val="stream"/>
-</obj>
-
-<obj class="OpMonURI" id="local-opmon-uri">
- <attr name="path" type="string" val="./info.json"/>
- <attr name="type" type="enum" val="file"/>
-</obj>
-
 <obj class="RCApplication" id="root-controller">
  <attr name="application_name" type="string" val="drunc-controller"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>

--- a/test/config/test-session.data.xml
+++ b/test/config/test-session.data.xml
@@ -63,7 +63,7 @@
 
 <oks-data>
 
-<info name="" type="" num-of-items="21" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T105549" last-modified-by="maroda" last-modified-on="np04-srv-015.cern.ch" last-modification-time="20240913T080846"/>
+<info name="" type="" num-of-items="19" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231207T105549" last-modified-by="maroda" last-modified-on="np04-srv-015.cern.ch" last-modification-time="20240916T092524"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
@@ -114,6 +114,9 @@
  <comment creation-time="20240826T084126" created-by="maroda" created-on="np04-srv-015.cern.ch" author="maroda" text="Correct cern stream"/>
  <comment creation-time="20240912T143615" created-by="maroda" created-on="np04-srv-015.cern.ch" author="maroda" text="add opmon objects"/>
  <comment creation-time="20240913T080846" created-by="maroda" created-on="np04-srv-015.cern.ch" author="maroda" text="remove opmon service objects"/>
+ <comment creation-time="20240916T091035" created-by="maroda" created-on="np04-srv-015.cern.ch" author="maroda" text="change monitoring object"/>
+ <comment creation-time="20240916T091131" created-by="maroda" created-on="np04-srv-015.cern.ch" author="maroda" text="remove old object"/>
+ <comment creation-time="20240916T092524" created-by="maroda" created-on="np04-srv-015.cern.ch" author="maroda" text="Correct locations for OpMonConf objects"/>
 </comments>
 
 
@@ -136,16 +139,6 @@
  <attr name="tpg_channel_map" type="string" val="PD2HDChannelMap"/>
  <attr name="clock_speed_hz" type="u32" val="62500000"/>
  <attr name="op_env" type="string" val="test"/>
-</obj>
-
-<obj class="OpMonConf" id="fast-all-monitoring">
- <attr name="level" type="u32" val="4294967295"/>
- <attr name="interval_s" type="u32" val="2"/>
-</obj>
-
-<obj class="OpMonConf" id="slow-all-monitoring">
- <attr name="level" type="u32" val="4294967295"/>
- <attr name="interval_s" type="u32" val="10"/>
 </obj>
 
 <obj class="OpMonURI" id="cern-opmon-uri">

--- a/test/config/trigger-segment.data.xml
+++ b/test/config/trigger-segment.data.xml
@@ -63,7 +63,7 @@
 
 <oks-data>
 
-<info name="" type="" num-of-items="25" oks-format="data" oks-version="862f2957270" created-by="asztuc" created-on="np04-srv-019.cern.ch" creation-time="20231212T171111" last-modified-by="maroda" last-modified-on="np04-srv-015.cern.ch" last-modification-time="20240912T143615"/>
+<info name="" type="" num-of-items="25" oks-format="data" oks-version="862f2957270" created-by="asztuc" created-on="np04-srv-019.cern.ch" creation-time="20231212T171111" last-modified-by="maroda" last-modified-on="np04-srv-015.cern.ch" last-modification-time="20240916T092524"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
@@ -71,8 +71,9 @@
  <file path="schema/appmodel/trigger.schema.xml"/>
  <file path="config/appmodel/connections.data.xml"/>
  <file path="config/appmodel/moduleconfs.data.xml"/>
- <file path="test/config/hosts.data.xml"/>
+ <file path="config/appmodel/opmon.data.xml"/>
  <file path="config/appmodel/fsm.data.xml"/>
+ <file path="test/config/hosts.data.xml"/>
 </include>
 
 <comments>
@@ -97,6 +98,8 @@
  <comment creation-time="20240403T115733" created-by="glehmann" created-on="np04-srv-019.cern.ch" author="glehmann" text=" "/>
  <comment creation-time="20240628T062322" created-by="thea" created-on="np04-srv-031.cern.ch" author="thea" text="removing broadcasters from control apps"/>
  <comment creation-time="20240912T143615" created-by="maroda" created-on="np04-srv-015.cern.ch" author="maroda" text="add opmon objects"/>
+ <comment creation-time="20240916T091035" created-by="maroda" created-on="np04-srv-015.cern.ch" author="maroda" text="change monitoring object"/>
+ <comment creation-time="20240916T092524" created-by="maroda" created-on="np04-srv-015.cern.ch" author="maroda" text="Correct locations for OpMonConf objects"/>
 </comments>
 
 


### PR DESCRIPTION
The previous configuration had OpMon objects defined in the session that were referenced by the segments. This PR should make things right.