### PR TITLE
Fix hermes link masking

### DIFF
--- a/src/WIECApplication.cpp
+++ b/src/WIECApplication.cpp
@@ -92,15 +92,10 @@ WIECApplication::generate_modules(conffwk::Configuration* config,
     // Loop over senders
     for (const auto* sender : det_senders) {
 
+      // Check the sender type, must me a HermesSender
       const auto* hrms_sender = sender->cast<appmodel::HermesDataSender>();
       if (!hrms_sender ) {
-        throw(BadConf(ERS_HERE, fmt::format("DataSender {} is not a appmodel::HermesDataSender",sender->UID())));
-      }
-
-      // Are we sure?
-      if (hrms_sender->disabled(*session)) {
-        TLOG_DEBUG(7) << "Ignoring disabled DetectorStream " << sender->UID();
-        continue;
+        throw(BadConf(ERS_HERE, fmt::format("DataSender {} is not a appmodel::HermesDataSender", sender->UID())));
       }
 
       ctrlhost_sender_map[hrms_sender->get_control_host()].push_back(hrms_sender);


### PR DESCRIPTION
The masking of hermes link was not properly supported. The cause was identified to WIECApp generation logic failing to create valid `HermesModule` configurations if one or more links are disabled.
Specifically, the generation logic did  not add a disabled HermesSender to the module configuration, while the module - having the control of all links in of the hermes block - requires the list of senders to be fully specified and handles the enabled/disabled state of each link internally.
This PR ensures that sender objects for all links belonging to a WIB are included in the module configuration.