### PR TITLE
Added two configuration parameters to the TPStreamWriterConf.  

### DIFF
--- a/schema/appmodel/application.schema.xml
+++ b/schema/appmodel/application.schema.xml
@@ -414,6 +414,8 @@
 
  <class name="TPStreamWriterConf">
   <attribute name="tp_accumulation_interval" type="u64" init-value="0" is-not-null="yes"/>
+  <attribute name="tp_accumulation_inactivity_time_before_write_sec" type="float" init-value="1.0" is-not-null="yes"/>
+  <attribute name="warn_user_when_tardy_tps_are_discarded" type="bool" init-value="true" is-not-null="yes"/>
   <relationship name="data_store_params" class-type="DataStoreConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
  </class>
 


### PR DESCRIPTION
These provide better control of how the TPStreamWriter handles tardy TPs.

There are changes in [dfmodules](https://github.com/DUNE-DAQ/dfmodules/pull/386) and [daqsystemtest](https://github.com/DUNE-DAQ/daqsystemtest/pull/131) that depend on this one, so they should be tested together.

