### PR TITLE
switched to using the TPWriter instance index (currently always zero)…

### DIFF
--- a/src/TPWriterApplication.cpp
+++ b/src/TPWriterApplication.cpp
@@ -84,10 +84,11 @@ TPStreamWriterApplication::generate_modules(conffwk::Configuration* confdb,
     throw(BadConf(ERS_HERE, "No SourceIDConf given to TPWriterApplication!"));  
   }
 
+  uint tpw_idx = 0;
   std::string tpwrUid("tpwriter-"+std::to_string(source_id->get_sid()));
   confdb->create(dbfile, "TPStreamWriterModule", tpwrUid, tpwrObj);
   tpwrObj.set_by_val<uint32_t>("source_id", source_id->get_sid());
-  tpwrObj.set_by_val("writer_identifier", fmt::format("{}_tpw_{}", UID(), source_id->get_sid()));
+  tpwrObj.set_by_val("writer_identifier", fmt::format("{}_tpw_{}", UID(), tpw_idx));
   tpwrObj.set_obj("configuration", &tpwriterConf->config_object());
   tpwrObj.set_objs("inputs", {&tset_in_net_obj} );
 


### PR DESCRIPTION
… in the TPStreamWriter data filename in TPWriterApplication, instead of the source_id, as discussed at the Core Software meeting last week.

The goal of this is to have the raw-data and tp-stream-data filenames be more consistent.
