### PR TITLE
Added the fragment network output connection to the MLT and Trigger apps...

### DIFF
--- a/src/MLTApplication.cpp
+++ b/src/MLTApplication.cpp
@@ -51,6 +51,7 @@
 #include "appmodel/ReadoutApplication.hpp"
 #include "appmodel/TriggerApplication.hpp"
 #include "appmodel/appmodelIssues.hpp"
+#include "appmodel/DFApplication.hpp"
 
 #include "appmodel/StandaloneTCMakerConf.hpp"
 #include "appmodel/StandaloneTCMakerModule.hpp"
@@ -406,6 +407,42 @@ MLTApplication::generate_modules(conffwk::Configuration* confdb,
    * Create the TC handler
    **************************************************************/
 
+  // Process special Network rules!
+  // Looking for Fragment rules from DFAppplications in current Session
+  auto sessionApps = session->get_enabled_applications();
+  std::vector<conffwk::ConfigObject> fragOutObjs;
+  for (auto app : sessionApps) {
+    auto dfapp = app->cast<appmodel::DFApplication>();
+    if (dfapp == nullptr)
+      continue;
+
+    auto dfNRules = dfapp->get_network_rules();
+    for (auto rule : dfNRules) {
+      auto descriptor = rule->get_descriptor();
+      auto data_type = descriptor->get_data_type();
+      if (data_type == "Fragment") {
+        std::string dreqNetUid(descriptor->get_uid_base() + dfapp->UID());
+        conffwk::ConfigObject frag_conn;
+        //create_mlt_network_connection(ti_net_desc->get_uid_base(), ti_net_desc, confdb, dbfile);
+        confdb->create(dbfile, "NetworkConnection", dreqNetUid, frag_conn);
+
+        frag_conn.set_by_val<std::string>("data_type", descriptor->get_data_type());
+        frag_conn.set_by_val<std::string>("connection_type", descriptor->get_connection_type());
+
+        auto serviceObj = descriptor->get_associated_service()->config_object();
+        frag_conn.set_obj("associated_service", &serviceObj);
+        fragOutObjs.push_back(frag_conn);
+      } // If network rule has TriggerDecision type of data
+    }   // Loop over Apps network rules
+  }     // loop over Session specific Apps
+
+  // build up the full list of outputs
+  std::vector<const conffwk::ConfigObject*> ti_output_objs;
+  for (auto& fNet : fragOutObjs) {
+    ti_output_objs.push_back(&fNet);
+  }
+  ti_output_objs.push_back(&output_queue_obj);
+
   auto tch_conf_obj = tch_conf->config_object();
   conffwk::ConfigObject ti_obj;
   if (get_source_id() == nullptr) {
@@ -420,7 +457,7 @@ MLTApplication::generate_modules(conffwk::Configuration* confdb,
   ti_obj.set_objs("enabled_source_ids", sourceIds);
   ti_obj.set_objs("mandatory_source_ids", mandatory_sids);
   ti_obj.set_objs("inputs", { &input_queue_obj, &dr_net_obj });
-  ti_obj.set_objs("outputs", { &output_queue_obj });
+  ti_obj.set_objs("outputs", ti_output_objs);
 
   // Add to our list of modules to return
   modules.push_back(confdb->get<DataHandlerModule>(ti_uid));

--- a/src/TriggerApplication.cpp
+++ b/src/TriggerApplication.cpp
@@ -34,6 +34,7 @@
 #include "appmodel/SourceIDConf.hpp"
 
 #include "appmodel/TriggerApplication.hpp"
+#include "appmodel/DFApplication.hpp"
 #include "appmodel/appmodelIssues.hpp"
 
 #include "logging/Logging.hpp"
@@ -82,7 +83,7 @@ create_network_connection(std::string uid,
 std::vector<const confmodel::DaqModule*>
 TriggerApplication::generate_modules(conffwk::Configuration* confdb,
                                      const std::string& dbfile,
-                                     const confmodel::Session* /*session*/) const
+                                     const confmodel::Session* session) const
 {
   std::vector<const confmodel::DaqModule*> modules;
 
@@ -99,7 +100,7 @@ TriggerApplication::generate_modules(conffwk::Configuration* confdb,
       ti_inputq_desc = rule->get_descriptor();
     }
   }
-  // Process the network rules looking for the Fragment Aggregator and TP handler data reuest inputs
+  // Process the network rules looking for the TP handler data reuest inputs
   const NetworkConnectionDescriptor* req_net_desc = nullptr;
   const NetworkConnectionDescriptor* tin_net_desc = nullptr;
   const NetworkConnectionDescriptor* tout_net_desc = nullptr;
@@ -149,6 +150,35 @@ TriggerApplication::generate_modules(conffwk::Configuration* confdb,
     }
   }
 
+  // Process special Network rules!
+  // Looking for Fragment rules from DFAppplications in current Session
+  auto sessionApps = session->get_enabled_applications();
+  std::vector<conffwk::ConfigObject> fragOutObjs;
+  for (auto app : sessionApps) {
+    auto dfapp = app->cast<appmodel::DFApplication>();
+    if (dfapp == nullptr)
+      continue;
+
+    auto dfNRules = dfapp->get_network_rules();
+    for (auto rule : dfNRules) {
+      auto descriptor = rule->get_descriptor();
+      auto data_type = descriptor->get_data_type();
+      if (data_type == "Fragment") {
+        std::string dreqNetUid(descriptor->get_uid_base() + dfapp->UID());
+        conffwk::ConfigObject frag_conn;
+        //create_mlt_network_connection(ti_net_desc->get_uid_base(), ti_net_desc, confdb, dbfile);
+        confdb->create(dbfile, "NetworkConnection", dreqNetUid, frag_conn);
+
+        frag_conn.set_by_val<std::string>("data_type", descriptor->get_data_type());
+        frag_conn.set_by_val<std::string>("connection_type", descriptor->get_connection_type());
+
+        auto serviceObj = descriptor->get_associated_service()->config_object();
+        frag_conn.set_obj("associated_service", &serviceObj);
+        fragOutObjs.push_back(frag_conn);
+      } // If network rule has TriggerDecision type of data
+    }   // Loop over Apps network rules
+  }     // loop over Session specific Apps
+
   // Now create the Data Handler and its associated queue and network
   // connections
   conffwk::ConfigObject input_queue_obj;
@@ -191,6 +221,16 @@ TriggerApplication::generate_modules(conffwk::Configuration* confdb,
                                                  tset_out_net_desc, confdb, dbfile);
   }
 
+  // build up the full list of outputs
+  std::vector<const conffwk::ConfigObject*> ti_output_objs;
+  for (auto& fNet : fragOutObjs) {
+    ti_output_objs.push_back(&fNet);
+  }
+  ti_output_objs.push_back(&tout_net_obj);
+  if (tset_out_net_desc!= nullptr) {
+    ti_output_objs.push_back(&tset_out_net_obj);
+  }
+
   auto ti_conf_obj = ti_conf->config_object();
   conffwk::ConfigObject ti_obj;
   if (get_source_id() == nullptr) {
@@ -205,14 +245,9 @@ TriggerApplication::generate_modules(conffwk::Configuration* confdb,
 
   ti_obj.set_obj("module_configuration", &ti_conf_obj);
   ti_obj.set_objs("inputs", {&input_queue_obj, &req_net_obj});
-  if (tset_out_net_desc!= nullptr) {
-    ti_obj.set_objs("outputs", {&tout_net_obj, &tset_out_net_obj});
-  }
-  else {
-    ti_obj.set_objs("outputs", {&tout_net_obj});
-  }
+  ti_obj.set_objs("outputs", ti_output_objs);
   // Add to our list of modules to return
-   modules.push_back(confdb->get<DataHandlerModule>(ti_uid));
+  modules.push_back(confdb->get<DataHandlerModule>(ti_uid));
 
 
   // Now create the DataSubscriberModule object


### PR DESCRIPTION
… for completeness and to match what is included in the Readout app.

I discovered that these connections were missing from the MLT and Trigger apps when trying to add "sender is ready" code to the `datahandlinglibs` `DefaultRequestHandlerModel` code, and I noticed that there were no fragment output connections in the MLT and Trigger app configs.  I need these output connections to be defined in order for my changes to check if Fragment senders are ready in `do_start()` methods to be fully beneficial.

The absence of these connections is nicely shown in the config diagrams that we can generate with the create_config_plot utility.  

The changes that I've made for this PR successfully provide this missing connection config information.  However, I can image a few follow-up actions:

- pull out the copy-pasted common code that looks up the fragment network connection into a function
- run the clang-format utility on the xyzApplication.cpp code
- check with Artur if there are ramifications from the disable_tx_generation config flag on the handling of DataRequests and sending of Fragments by Trigger apps.

I propose to take care of those in separate Issues and Pull Requests.

I can provide instructions for testing these changes, both by generating config plots and running regression tests, if desired.

Attached are sample diagrams that illustrate the problem and the fix.  The first diagram shows the Readout app config from the `minimal_system_quick_test` (regression test) configuration.  It **does** have the `fragments_df-01` external connection.  The second diagram shows the MLT app from the MSQT test before the fix.  It does **not** show the `fragments_df-01` connection.  The third diagram shows the MLT config after the fix, and it does show the `fragments_df-01` connection.

![17Dec_msqt_ruapp](https://github.com/user-attachments/assets/3c36e7ef-5510-4c03-a07c-44f6fad7cb64)
![17Dec_msqt_mlt](https://github.com/user-attachments/assets/f361b521-432a-4e42-a881-38ee460ecfaa)
![18Dec_msqt_mlt](https://github.com/user-attachments/assets/8712e174-7e57-4b07-9e69-57963b867eac)
