### PR TITLE
Use common object factory code to generate configuration objects

### DIFF
--- a/include/appmodel/ConfigurationHelper.hpp
+++ b/include/appmodel/ConfigurationHelper.hpp
@@ -10,6 +10,9 @@
 #ifndef APPMODEL_INCLUDE_CONFIGURATIONHELPER_HPP_
 #define APPMODEL_INCLUDE_CONFIGURATIONHELPER_HPP_
 
+#include "appmodel/ObjectFactory.hpp"
+#include "confmodel/Session.hpp"
+
 #include <cstdint>
 #include <map>
 #include <string>
@@ -17,7 +20,6 @@
 #include <vector>
 
 namespace dunedaq::confmodel {
-  class Session;
   class Service;
 } //namespace dunedaq::confmodel
 namespace dunedaq::conffwk {
@@ -30,9 +32,11 @@ namespace dunedaq::appmodel {
 
   class ConfigurationHelper {
   public:
-    explicit ConfigurationHelper(const confmodel::Session* ses)
-      : m_session(ses) {}
-
+    explicit ConfigurationHelper(const confmodel::Session* ses, std::string app_uid)
+      : m_session(ses),
+        m_object_factory(&m_session->configuration(),
+                         m_session->config_object().contained_in(),
+                         app_uid) {}
 
     /// Get the exposed Services of all network connections with given
     /// data_type from all applications of given type 
@@ -63,8 +67,13 @@ namespace dunedaq::appmodel {
     /// Check the enabled state of the given item
     bool enabled(const conffwk::DalObject* item);
 
+    /// Get the object factory
+    const ObjectFactory& object_factory() {
+      return m_object_factory;
+    }
   private:
     const confmodel::Session* m_session;
+    ObjectFactory m_object_factory;
   };
 
 } //namespace dunedaq::appmodel

--- a/include/appmodel/ObjectFactory.hpp
+++ b/include/appmodel/ObjectFactory.hpp
@@ -1,0 +1,114 @@
+/**
+ * @file ObjectFactory.hpp
+ *
+ * Define a helper class for SmartDaqApplication module generators
+ *
+ * This is part of the DUNE DAQ Software Suite, copyright 2023.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+#ifndef APPMODEL_INCLUDE_OBJECTFACTORY_HPP_
+#define APPMODEL_INCLUDE_OBJECTFACTORY_HPP_
+
+#include "appmodel/NetworkConnectionDescriptor.hpp"
+#include "appmodel/QueueDescriptor.hpp"
+
+#include "conffwk/Configuration.hpp"
+
+#include "confmodel/DetectorStream.hpp"
+#include "confmodel/Service.hpp"
+
+#include <fmt/core.h>  // Replace with std::format when we switch to a newer compiler?
+
+namespace dunedaq::appmodel {
+
+class ObjectFactory {
+
+  conffwk::Configuration* m_config;
+  std::string m_dbfile;
+  std::string m_app_uid;
+
+  public:
+  ObjectFactory(conffwk::Configuration* config, std::string dbfile,
+                    std::string app_uid) : m_config(config), m_dbfile(dbfile),
+                                           m_app_uid(app_uid) {
+  }
+
+
+  conffwk::ConfigObject create(const std::string& class_name, const std::string& id) const {
+    conffwk::ConfigObject cfg_obj;
+    m_config->create(m_dbfile, class_name, id, cfg_obj);
+    // m_config->create(m_dbfile, class_name, fmt::format("{}_{}", m_app_uid, id), cfg_obj);
+    return cfg_obj;
+  }
+
+  //---
+  conffwk::ConfigObject create_queue_obj(const QueueDescriptor* qdesc, std::string uid="") const {
+    // conffwk::ConfigObject queue_obj;
+
+    std::string queue_uid(qdesc->get_uid_base() + uid);
+    auto queue_obj = create("Queue", queue_uid);
+    queue_obj.set_by_val<std::string>("data_type", qdesc->get_data_type());
+    queue_obj.set_by_val<std::string>("queue_type", qdesc->get_queue_type());
+    queue_obj.set_by_val<uint32_t>("capacity", qdesc->get_capacity());
+
+    return queue_obj;
+  }
+
+  //---
+  conffwk::ConfigObject create_queue_sid_obj(const QueueDescriptor* qdesc,
+                                             uint32_t src_id) const {
+    std::string queue_uid(fmt::format("{}{}", qdesc->get_uid_base(), src_id));
+    auto queue_obj = create("QueueWithSourceId", queue_uid);
+
+    queue_obj.set_by_val<std::string>("data_type", qdesc->get_data_type());
+    queue_obj.set_by_val<std::string>("queue_type", qdesc->get_queue_type());
+    queue_obj.set_by_val<uint32_t>("capacity", qdesc->get_capacity());
+    queue_obj.set_by_val<uint32_t>("source_id", src_id);
+
+    return queue_obj;
+  }
+
+  //---
+  conffwk::ConfigObject create_queue_sid_obj(const QueueDescriptor* qdesc,
+                                             const confmodel::DetectorStream* stream) const {
+    return create_queue_sid_obj(qdesc, stream->get_source_id());
+  }
+
+
+
+  //---
+
+  /**
+   * \brief Helper function that gets a network connection config
+   *
+   * \param uid  Unique ID name of the config object
+   * \param ndesc Network connection descriptor object
+   *
+   * \ret OKS configuration object for the network connection
+   */
+  conffwk::ConfigObject create_net_obj(const NetworkConnectionDescriptor* ndesc,
+                                       std::string uid) const {
+    // conffwk::ConfigObject net_obj;
+
+    auto svc_obj = ndesc->get_associated_service()->config_object();
+    std::string net_id = ndesc->get_uid_base() + uid;
+    auto net_obj = create("NetworkConnection", net_id);
+
+    net_obj.set_by_val<std::string>("data_type", ndesc->get_data_type());
+    net_obj.set_by_val<std::string>("connection_type", ndesc->get_connection_type());
+    net_obj.set_obj("associated_service", &svc_obj);
+
+    return net_obj;
+
+  }
+
+  conffwk::ConfigObject create_net_obj(const NetworkConnectionDescriptor* ndesc) const {
+    return create_net_obj(ndesc, this->m_app_uid);
+  }
+
+};
+
+} //namespace dunedaq::appmodel
+
+#endif // APPMODEL_INCLUDE_OBJECTFACTORY_HPP_

--- a/pybindsrc/dal_methods.cpp
+++ b/pybindsrc/dal_methods.cpp
@@ -49,7 +49,7 @@ namespace dunedaq::appmodel::python {
     const auto app =
       const_cast<conffwk::Configuration&>(confdb).get<ApplicationType>(app_id);
     const auto* session = const_cast<conffwk::Configuration&>(confdb).get<dunedaq::confmodel::Session>(session_id);
-    auto helper = std::make_shared<ConfigurationHelper>(session);
+    auto helper = std::make_shared<ConfigurationHelper>(session, app_id);
     std::vector<ObjectLocator> mods;
     for (auto mod : app->generate_modules(
            const_cast<conffwk::Configuration*>(&confdb), dbfile, helper)) {

--- a/src/DFApplication.cpp
+++ b/src/DFApplication.cpp
@@ -53,25 +53,6 @@ static ModuleFactory::Registrator __reg__("DFApplication",
                                           });
 
 inline void
-fill_queue_object_from_desc(const QueueDescriptor* qDesc, conffwk::ConfigObject& qObj)
-{
-  qObj.set_by_val<std::string>("data_type", qDesc->get_data_type());
-  qObj.set_by_val<std::string>("queue_type", qDesc->get_queue_type());
-  qObj.set_by_val<uint32_t>("capacity", qDesc->get_capacity());
-}
-
-inline void
-fill_netconn_object_from_desc(const NetworkConnectionDescriptor* netDesc, conffwk::ConfigObject& netObj)
-{
-  netObj.set_by_val<std::string>("data_type", netDesc->get_data_type());
-  netObj.set_by_val<std::string>("connection_type", netDesc->get_connection_type());
-
-  auto serviceObj = netDesc->get_associated_service()->config_object();
-  netObj.set_obj("associated_service", &serviceObj);
-}
-
-
-inline void
 fill_sourceid_object_from_app(conffwk::Configuration* confdb,
                               const std::string& dbfile,
                               const conffwk::ConfigObject* netConn,
@@ -111,44 +92,6 @@ fill_sourceid_object_from_app(conffwk::Configuration* confdb,
   sidNetObj.set_objs("source_ids", source_id_objs);
 }
 
-inline void
-fill_sourceid_object_from_app(conffwk::Configuration* confdb,
-                              const std::string& dbfile,
-                              const FakeDataApplication* fdapp,
-                              const conffwk::ConfigObject* netConn,
-                              conffwk::ConfigObject& sidNetObj,
-                              std::vector<std::shared_ptr<conffwk::ConfigObject>> sidObjs)
-{
-  sidNetObj.set_obj("netconn", netConn);
-
-  std::vector<const conffwk::ConfigObject*> source_id_objs;
-  std::vector<uint32_t> app_source_ids;
-
-  for (auto fdp_res : fdapp->get_contains()) {
-
-    // get the readout groups and the interfaces and streams therein; 1 reaout group corresponds to 1 data reader
-    // module
-    auto fdpc = fdp_res->cast<appmodel::FakeDataProdConf>();
-
-    if (!fdpc) {
-      continue;
-    }
-
-    app_source_ids.push_back(fdpc->get_source_id());
-  }
-
-  for (auto& source_id : app_source_ids) {
-    auto stream_sid_obj = std::make_shared<conffwk::ConfigObject>();
-    std::string streamSidUid(fdapp->UID() + "SourceIDConf" + std::to_string(source_id));
-    confdb->create(dbfile, "SourceIDConf", streamSidUid, *stream_sid_obj);
-    stream_sid_obj->set_by_val<uint32_t>("sid", source_id);
-    stream_sid_obj->set_by_val<std::string>("subsystem", "Detector_Readout");
-    sidObjs.push_back(stream_sid_obj);
-    source_id_objs.push_back(sidObjs.back().get());
-  }
-
-  sidNetObj.set_objs("source_ids", source_id_objs);
-}
 
 std::vector<const confmodel::DaqModule*>
 DFApplication::generate_modules(conffwk::Configuration* confdb,
@@ -156,6 +99,8 @@ DFApplication::generate_modules(conffwk::Configuration* confdb,
                                 std::shared_ptr<appmodel::ConfigurationHelper> helper) const
 {
   std::vector<const confmodel::DaqModule*> modules;
+
+  const ObjectFactory obj_fac = helper->object_factory();
 
   // Containers for module specific config objects for output/input
   // Prepare TRB output objects
@@ -176,10 +121,8 @@ DFApplication::generate_modules(conffwk::Configuration* confdb,
     throw(BadConf(ERS_HERE, "Could not find queue descriptor rule for TriggerRecords!"));
   }
   // Create queue connection config object
-  conffwk::ConfigObject trQueueObj;
-  std::string trQueueUid(trQDesc->get_uid_base() + UID());
-  confdb->create(dbfile, "Queue", trQueueUid, trQueueObj);
-  fill_queue_object_from_desc(trQDesc, trQueueObj);
+  auto trQueueObj = obj_fac.create_queue_obj(trQDesc, UID());
+
   // Place trigger record queue object into vector of output objs of TRB module
   trbOutputObjs.push_back(&trQueueObj);
 
@@ -211,18 +154,10 @@ DFApplication::generate_modules(conffwk::Configuration* confdb,
     throw(BadConf(ERS_HERE, "Could not retrieve SourceIDConf"));
   }
   // Create network connection config object
-  conffwk::ConfigObject fragNetObj;
-  conffwk::ConfigObject trigdecNetObj;
-  conffwk::ConfigObject tokenNetObj;
-  std::string fragNetUid = fragNetDesc->get_uid_base() + UID();
-  std::string trigdecNetUid = trigdecNetDesc->get_uid_base() + UID();
-  std::string tokenNetUid = tokenNetDesc->get_uid_base();
-  confdb->create(dbfile, "NetworkConnection", fragNetUid, fragNetObj);
-  confdb->create(dbfile, "NetworkConnection", trigdecNetUid, trigdecNetObj);
-  confdb->create(dbfile, "NetworkConnection", tokenNetUid, tokenNetObj);
-  fill_netconn_object_from_desc(fragNetDesc, fragNetObj);
-  fill_netconn_object_from_desc(trigdecNetDesc, trigdecNetObj);
-  fill_netconn_object_from_desc(tokenNetDesc, tokenNetObj);
+
+  auto fragNetObj = obj_fac.create_net_obj(fragNetDesc, UID());
+  auto trigdecNetObj =  obj_fac.create_net_obj(trigdecNetDesc, UID());
+  auto tokenNetObj = obj_fac.create_net_obj(tokenNetDesc, "");
 
   // Process special Network rules!
   // Looking for DataRequest rules from ReadoutAppplications in current Session
@@ -237,10 +172,7 @@ DFApplication::generate_modules(conffwk::Configuration* confdb,
   auto tp_src_ids = helper->get_tp_source_ids();
   for (auto [uid, descriptor]:
          helper->get_netdescriptors("DataRequest", "ReadoutApplication")) {
-    std::string dreqNetUid(descriptor->get_uid_base() + uid);
-    dreqNetObjs.emplace_back();
-    confdb->create(dbfile, "NetworkConnection", dreqNetUid, dreqNetObjs.back());
-    fill_netconn_object_from_desc(descriptor, dreqNetObjs.back());
+    dreqNetObjs.emplace_back(obj_fac.create_net_obj(descriptor, uid));
 
     std::string sidToNetUid(descriptor->get_uid_base() + uid + "-sids");
     sidNetObjs.emplace_back();
@@ -259,10 +191,8 @@ DFApplication::generate_modules(conffwk::Configuration* confdb,
   }
   for (auto [uid, descriptor]:
          helper->get_netdescriptors("DataRequest", "FakeDataApplication")) {
-    std::string dreqNetUid(descriptor->get_uid_base() + uid);
-    dreqNetObjs.emplace_back();
-    confdb->create(dbfile, "NetworkConnection", dreqNetUid, dreqNetObjs.back());
-    fill_netconn_object_from_desc(descriptor, dreqNetObjs.back());
+
+    dreqNetObjs.emplace_back(obj_fac.create_net_obj(descriptor, uid));
 
     std::string sidToNetUid(descriptor->get_uid_base() + uid + "-sids");
     sidNetObjs.emplace_back();
@@ -287,15 +217,11 @@ DFApplication::generate_modules(conffwk::Configuration* confdb,
       continue;
     }
     if (app_sources.contains(uid)) {
-      std::string dreqNetUid(descriptor->get_uid_base() + uid);
-      dreqNetObjs.emplace_back();
-      confdb->create(dbfile, "NetworkConnection", dreqNetUid, dreqNetObjs.back());
-      fill_netconn_object_from_desc(descriptor, dreqNetObjs.back());
+      dreqNetObjs.emplace_back(obj_fac.create_net_obj(descriptor, uid));
 
       std::string sidToNetUid(descriptor->get_uid_base() + uid + "-sids");
-      sidNetObjs.emplace_back();
-      confdb->create(dbfile, "SourceIDToNetworkConnection", sidToNetUid,
-                     sidNetObjs.back());
+      sidNetObjs.emplace_back(
+        obj_fac.create("SourceIDToNetworkConnection", sidToNetUid));
       sidNetObjs.back().set_obj("netconn", &dreqNetObjs.back());
       sidNetObjs.back().set_objs("source_ids", { &app_sources[uid]->config_object() });
     }
@@ -321,9 +247,8 @@ DFApplication::generate_modules(conffwk::Configuration* confdb,
   auto trbConfObj = trbConf->config_object();
   trbConfObj.set_by_val<uint32_t>("source_id", get_source_id()->get_sid());
   // Prepare TRB Module Object and assign its Config Object.
-  conffwk::ConfigObject trbObj;
   std::string trbUid(UID() + "-trb");
-  confdb->create(dbfile, "TRBModule", trbUid, trbObj);
+  auto trbObj = obj_fac.create("TRBModule", trbUid);
   trbObj.set_obj("configuration", &trbConfObj);
   trbObj.set_objs("inputs", { &trigdecNetObj, &fragNetObj });
   trbObj.set_objs("outputs", trbOutputObjs);
@@ -343,9 +268,8 @@ DFApplication::generate_modules(conffwk::Configuration* confdb,
     auto dwrConfObj = dwrConf->config_object();
 
     // Prepare DataWriterModule Module Object and assign its Config Object.
-    conffwk::ConfigObject dwrObj;
     std::string dwrUid(fmt::format("{}-dw-{}", UID(), dw_idx));
-    confdb->create(dbfile, "DataWriterModule", dwrUid, dwrObj);
+    auto dwrObj = obj_fac.create("DataWriterModule", dwrUid);
     dwrObj.set_by_val("writer_identifier", fmt::format("{}_dw_{}", UID(), dw_idx));
     dwrObj.set_obj("configuration", &dwrConfObj);
     dwrObj.set_objs("inputs", { &trQueueObj });

--- a/src/MLTApplication.cpp
+++ b/src/MLTApplication.cpp
@@ -73,31 +73,6 @@ static ModuleFactory::Registrator __reg__("MLTApplication",
                                             return app->generate_modules(confdb, dbfile, helper);
                                           });
 
-/**
- * \brief Helper function that gets a network connection config
- *
- * \param idname Unique ID name of the config object
- * \param ntDesc Network connection descriptor object
- * \param confdb Global database configuration
- * \param dbfile Database file location
- *
- * \ret OKS configuration object for the network connection
- */
-conffwk::ConfigObject
-create_mlt_network_connection(std::string uid,
-                              const NetworkConnectionDescriptor* ntDesc,
-                              conffwk::Configuration* confdb,
-                              const std::string& dbfile)
-{
-  auto ntServiceObj = ntDesc->get_associated_service()->config_object();
-  conffwk::ConfigObject ntObj;
-  confdb->create(dbfile, "NetworkConnection", uid, ntObj);
-  ntObj.set_by_val<std::string>("data_type", ntDesc->get_data_type());
-  ntObj.set_by_val<std::string>("connection_type", ntDesc->get_connection_type());
-  ntObj.set_obj("associated_service", &ntServiceObj);
-
-  return ntObj;
-}
 
 std::vector<const confmodel::DaqModule*>
 MLTApplication::generate_modules(conffwk::Configuration* confdb,
@@ -105,6 +80,8 @@ MLTApplication::generate_modules(conffwk::Configuration* confdb,
                                  std::shared_ptr<appmodel::ConfigurationHelper> helper) const
 {
   std::vector<const confmodel::DaqModule*> modules;
+
+  const ObjectFactory obj_fac = helper->object_factory();
 
   // auto mlt_conf = get_mlt_conf();
   // auto mlt_class = mlt_conf->get_template_for();
@@ -204,23 +181,23 @@ MLTApplication::generate_modules(conffwk::Configuration* confdb,
   // Network connection for input TriggerInhibit, input TCs
 
   conffwk::ConfigObject ti_net_obj =
-    create_mlt_network_connection(ti_net_desc->get_uid_base(), ti_net_desc, confdb, dbfile);
+    obj_fac.create_net_obj(ti_net_desc, "");
 
   conffwk::ConfigObject tc_net_obj =
-    create_mlt_network_connection(tc_net_desc->get_uid_base() + ".*", tc_net_desc, confdb, dbfile);
+    obj_fac.create_net_obj(tc_net_desc, ".*");
 
   // Network connection for output TriggerDecision
   conffwk::ConfigObject td_net_obj =
-    create_mlt_network_connection(td_net_desc->get_uid_base(), td_net_desc, confdb, dbfile);
+    obj_fac.create_net_obj(td_net_desc, "");
 
   // Network conection for the input Data Requests
   conffwk::ConfigObject dr_net_obj =
-    create_mlt_network_connection(req_net_desc->get_uid_base() + UID(), req_net_desc, confdb, dbfile);
+    obj_fac.create_net_obj(req_net_desc, UID());
 
   conffwk::ConfigObject timesync_net_obj;
   if (timesync_net_desc != nullptr) {
     timesync_net_obj =
-      create_mlt_network_connection(timesync_net_desc->get_uid_base() + ".*", timesync_net_desc, confdb, dbfile);
+      obj_fac.create_net_obj(timesync_net_desc, ".*");
   }
 
   /**************************************************************
@@ -239,7 +216,7 @@ MLTApplication::generate_modules(conffwk::Configuration* confdb,
     }
 
     auto tc_net_gen =
-      create_mlt_network_connection(tc_net_desc->get_uid_base() + gen_conf->UID(), tc_net_desc, confdb, dbfile);
+      obj_fac.create_net_obj(tc_net_desc, gen_conf->UID());
     generated_tc_conns.push_back(tc_net_gen);
 
     gen_obj.set_objs("outputs", { &generated_tc_conns.back() });

--- a/src/ReadoutApplication.cpp
+++ b/src/ReadoutApplication.cpp
@@ -12,6 +12,7 @@
 
 #include "appmodel/ConfigurationHelper.hpp"
 #include "appmodel/DFApplication.hpp"
+#include "appmodel/ObjectFactory.hpp"
 #include "appmodel/ReadoutApplication.hpp"
 #include "conffwk/Configuration.hpp"
 #include "confmodel/DetDataReceiver.hpp"
@@ -70,90 +71,17 @@ namespace appmodel {
   return app->generate_modules(config, dbfile, helper);
 });
 
-class ReadoutObjFactory {
-  public:
-
-  conffwk::Configuration* config;
-  std::string dbfile;
-  std::string app_uid;
-
-
-  conffwk::ConfigObject create(const std::string& class_name, const std::string& id) {
-    conffwk::ConfigObject cfg_obj;
-    config->create(this->dbfile, class_name, id, cfg_obj);
-    // config->create(this->dbfile, class_name, fmt::format("{}_{}", app_uid, id), cfg_obj);
-    return cfg_obj;
-  }
-
-  //---
-  conffwk::ConfigObject create_queue_obj(const QueueDescriptor* qdesc) {
-    // conffwk::ConfigObject queue_obj;
-
-    std::string queue_uid(qdesc->get_uid_base());
-    // config->create(this->dbfile, "Queue", queue_uid, queue_obj);
-    auto queue_obj = this->create("Queue", queue_uid);
-    queue_obj.set_by_val<std::string>("data_type", qdesc->get_data_type());
-    queue_obj.set_by_val<std::string>("queue_type", qdesc->get_queue_type());
-    queue_obj.set_by_val<uint32_t>("capacity", qdesc->get_capacity());
-
-    return queue_obj;
-  }
-
-  //---
-  conffwk::ConfigObject create_queue_sid_obj(const QueueDescriptor* qdesc, uint32_t src_id) {
-    // conffwk::ConfigObject queue_obj;
-
-    std::string queue_uid(fmt::format("{}{}", qdesc->get_uid_base(), src_id));
-    // config->create(this->dbfile, "QueueWithSourceId", queue_uid, queue_obj);
-    auto queue_obj = this->create("QueueWithSourceId", queue_uid);
-
-    queue_obj.set_by_val<std::string>("data_type", qdesc->get_data_type());
-    queue_obj.set_by_val<std::string>("queue_type", qdesc->get_queue_type());
-    queue_obj.set_by_val<uint32_t>("capacity", qdesc->get_capacity());
-    queue_obj.set_by_val<uint32_t>("source_id", src_id);
-
-    return queue_obj;
-  }
-
-  //---
-  conffwk::ConfigObject create_queue_sid_obj(const QueueDescriptor* qdesc, const confmodel::DetectorStream* stream) {
-    return this->create_queue_sid_obj(qdesc, stream->get_source_id());
-  }
-
-
-
-  //---
-  conffwk::ConfigObject create_net_obj(const NetworkConnectionDescriptor* ndesc, std::string uid) {
-    // conffwk::ConfigObject net_obj;
-
-    auto svc_obj = ndesc->get_associated_service()->config_object();
-    std::string net_id = ndesc->get_uid_base() + uid;
-    // config->create(this->dbfile, "NetworkConnection", net_id, net_obj);
-    auto net_obj = this->create("NetworkConnection", net_id);
-
-    net_obj.set_by_val<std::string>("data_type", ndesc->get_data_type());
-    net_obj.set_by_val<std::string>("connection_type", ndesc->get_connection_type());
-    net_obj.set_obj("associated_service", &svc_obj);
-
-    return net_obj;
-
-  }
-
-  conffwk::ConfigObject create_net_obj(const NetworkConnectionDescriptor* ndesc) {
-    return this->create_net_obj(ndesc, this->app_uid);
-  }
-
-
-};
-
 //-----------------------------------------------------------------------------
 std::vector<const confmodel::DaqModule*>
-ReadoutApplication::generate_modules(conffwk::Configuration* config, const std::string& dbfile, std::shared_ptr<ConfigurationHelper> helper) const
+ReadoutApplication::generate_modules(
+  conffwk::Configuration* config,
+  const std::string& /*dbfile*/,
+  std::shared_ptr<ConfigurationHelper> helper) const
 {
 
   TLOG_DEBUG(6) << "Generating modules for application " << this->UID();
 
-  ReadoutObjFactory obj_fac{config, dbfile, this->UID()};
+  const auto obj_fac = helper->object_factory();
   //
   // Extract basic configuration objects
   //

--- a/src/TriggerApplication.cpp
+++ b/src/TriggerApplication.cpp
@@ -11,6 +11,8 @@
 #include "ModuleFactory.hpp"
 
 #include "appmodel/ConfigurationHelper.hpp"
+#include "appmodel/ObjectFactory.hpp"
+
 #include "conffwk/Configuration.hpp"
 
 #include "confmodel/Connection.hpp"
@@ -54,31 +56,6 @@ static ModuleFactory::Registrator __reg__("TriggerApplication",
                                             return app->generate_modules(confdb, dbfile, helper);
                                           });
 
-/**
- * \brief Helper function that gets a network connection config
- *
- * \param idname Unique ID name of the config object
- * \param ntDesc Network connection descriptor object
- * \param confdb Global database configuration
- * \param dbfile Database file location
- *
- * \ret OKS configuration object for the network connection
- */
-conffwk::ConfigObject
-create_network_connection(std::string uid,
-                          const NetworkConnectionDescriptor* ntDesc,
-                          conffwk::Configuration* confdb,
-                          const std::string& dbfile)
-{
-  auto ntServiceObj = ntDesc->get_associated_service()->config_object();
-  conffwk::ConfigObject ntObj;
-  confdb->create(dbfile, "NetworkConnection", uid, ntObj);
-  ntObj.set_by_val<std::string>("data_type", ntDesc->get_data_type());
-  ntObj.set_by_val<std::string>("connection_type", ntDesc->get_connection_type());
-  ntObj.set_obj("associated_service", &ntServiceObj);
-
-  return ntObj;
-}
 
 std::vector<const confmodel::DaqModule*>
 TriggerApplication::generate_modules(conffwk::Configuration* confdb,
@@ -86,6 +63,8 @@ TriggerApplication::generate_modules(conffwk::Configuration* confdb,
                                      std::shared_ptr<appmodel::ConfigurationHelper> helper) const
 {
   std::vector<const confmodel::DaqModule*> modules;
+
+  const ObjectFactory obj_fac = helper->object_factory();
 
   auto ti_conf = get_trigger_inputs_handler();
   auto ti_class = ti_conf->get_template_for();
@@ -170,11 +149,6 @@ TriggerApplication::generate_modules(conffwk::Configuration* confdb,
 
   // Now create the Data Handler and its associated queue and network
   // connections
-  conffwk::ConfigObject input_queue_obj;
-  conffwk::ConfigObject req_net_obj;
-  conffwk::ConfigObject tin_net_obj;
-  conffwk::ConfigObject tout_net_obj;
-  conffwk::ConfigObject tset_out_net_obj;
 
   if ( req_net_desc== nullptr) {
       throw (BadConf(ERS_HERE, "No network descriptor given to receive request and send data was set"));
@@ -189,25 +163,21 @@ TriggerApplication::generate_modules(conffwk::Configuration* confdb,
       throw (BadConf(ERS_HERE, "No data input queue descriptor given"));
   }
 
-  std::string queue_uid(ti_inputq_desc->get_uid_base());
-  confdb->create(dbfile, "Queue", queue_uid, input_queue_obj);
-  input_queue_obj.set_by_val<std::string>("data_type", ti_inputq_desc->get_data_type());
-  input_queue_obj.set_by_val<std::string>("queue_type", ti_inputq_desc->get_queue_type());
-  input_queue_obj.set_by_val<uint32_t>("capacity", ti_inputq_desc->get_capacity());
 
-  
-  req_net_obj = create_network_connection(req_net_desc->get_uid_base()+UID(),
-                                           req_net_desc, confdb, dbfile);
+  auto input_queue_obj = obj_fac.create_queue_obj(ti_inputq_desc);
 
-  tin_net_obj = create_network_connection(tin_net_desc->get_uid_base()+".*",
-                                          tin_net_desc, confdb, dbfile);
+  auto req_net_obj = obj_fac.create_net_obj(req_net_desc,
+                                            req_net_desc->get_uid_base()+UID());
 
-  tout_net_obj = create_network_connection(tout_net_desc->get_uid_base()+UID(),
-                                          tout_net_desc, confdb, dbfile);
+  auto tin_net_obj = obj_fac.create_net_obj(tin_net_desc,
+                                            tin_net_desc->get_uid_base()+".*");
 
+  auto tout_net_obj = obj_fac.create_net_obj(tout_net_desc,
+                                             tout_net_desc->get_uid_base()+UID());
+  conffwk::ConfigObject tset_out_net_obj;
   if (tset_out_net_desc) {
-    tset_out_net_obj = create_network_connection(tset_out_net_desc->get_uid_base()+UID(),
-                                                 tset_out_net_desc, confdb, dbfile);
+    tset_out_net_obj = obj_fac.create_net_obj(tset_out_net_desc,
+                                              tset_out_net_desc->get_uid_base()+UID());
   }
 
   // build up the full list of outputs

--- a/test/apps/generate_modules_test.cxx
+++ b/test/apps/generate_modules_test.cxx
@@ -68,7 +68,7 @@ int main(int argc, char* argv[]) {
       return 0;
     }
 
-    auto helper = std::make_shared<ConfigurationHelper>(session);
+    auto helper = std::make_shared<ConfigurationHelper>(session, appName);
 
     std::vector<const confmodel::DaqModule*> modules;
     try {

--- a/test/apps/print_detailed_config_info.cxx
+++ b/test/apps/print_detailed_config_info.cxx
@@ -162,9 +162,8 @@ main(int argc, char* argv[])
       return 0;
     }
     session = confdb->get<confmodel::Session>(sessionName);
-    auto helper = std::make_shared<ConfigurationHelper>(session);
-
     std::string appName = list_of_application_names[idx];
+    auto helper = std::make_shared<ConfigurationHelper>(session, appName);
     auto daqapp = confdb->get<appmodel::SmartDaqApplication>(appName);
     if (daqapp) {
       std::cout << appName << " is of class " << daqapp->class_name() << std::endl;


### PR DESCRIPTION
Add a helper class to create configuration objects for smart application `generate_modules()` methods. In this PR the code is accessed via the configuration helper introduced in #171 but the code is separate and an `ObjectFactory` could be instantiated without the helper.