### PR TITLE
Add and use FEMB enable flags to WIBModule configuration class #60

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,9 +20,9 @@ daq_oks_codegen(application.schema.xml hermes.schema.xml fdmodules.schema.xml tr
   NAMESPACE dunedaq::appmodel DEP_PKGS confmodel)
 
 daq_add_library(ReadoutApplication.cpp SmartDaqApplication.cpp
-	DFApplication.cpp DFOApplication.cpp TPWriterApplication.cpp FakeDataApplication.cpp FakeHSIApplication.cpp DTSHSIApplication.cpp TriggerApplication.cpp MLTApplication.cpp HSIEventToTCApplication.cpp WIECApplication.cpp DaphneApplication.cpp SocketSenderApplication.cpp
- LINK_LIBRARIES conffwk::conffwk fmt::fmt
-  logging::logging confmodel::confmodel oks::oks ers::ers)
+        DFApplication.cpp DFOApplication.cpp TPWriterApplication.cpp FakeDataApplication.cpp FakeHSIApplication.cpp DTSHSIApplication.cpp TriggerApplication.cpp MLTApplication.cpp HSIEventToTCApplication.cpp WIECApplication.cpp DaphneApplication.cpp SocketSenderApplication.cpp
+        LINK_LIBRARIES conffwk::conffwk fmt::fmt
+        logging::logging confmodel::confmodel oks::oks ers::ers)
 
 daq_add_application(getAppsArguments get_apps_arguments.cxx
   LINK_LIBRARIES confmodel::confmodel appmodel conffwk::conffwk)

--- a/docs/SmartDaqApplication.md
+++ b/docs/SmartDaqApplication.md
@@ -74,7 +74,7 @@ In addition to the fields from SmartDaqApplication, the DFOApplication class has
       }
     
     else if (descriptor->get_data_type() == "TriggerInhibit") {
-	busyOutObj = connObj;
+        busyOutObj = connObj;
         output_conns.push_back(&busyOutObj);
     }
   }

--- a/include/appmodel/appmodelIssues.hpp
+++ b/include/appmodel/appmodelIssues.hpp
@@ -12,14 +12,14 @@ namespace dunedaq {
                     ((std::string)id) ((std::string)stype))
 
   ERS_DECLARE_ISSUE(appmodel,
-		    MissingIP,
-		    "Daphne configuration has no IP " << ip,
-		    ((std::string)ip))
+        MissingIP,
+        "Daphne configuration has no IP " << ip,
+        ((std::string)ip))
 
   ERS_DECLARE_ISSUE(appmodel,
-		    MissingDaphne,
-		    "Daphne " << id << " has active channels but its turned off",
-		    ((size_t)id))
+        MissingDaphne,
+        "Daphne " << id << " has active channels but its turned off",
+        ((size_t)id))
 
 }
 

--- a/schema/appmodel/wiec.schema.xml
+++ b/schema/appmodel/wiec.schema.xml
@@ -102,7 +102,7 @@
  </class>
 
  <class name="FEMBSettings">
-  <attribute name="enabled" description="True of FEMB should be configured and read out by WIB" type="bool" init-value="true" is-not-null="yes"/>
+  <!-- <attribute name="enabled" description="True of FEMB should be configured and read out by WIB" type="bool" init-value="true" is-not-null="yes"/> -->
   <attribute name="test_cap" description="Enable the test capacitor" type="bool" init-value="false" is-not-null="yes"/>
   <attribute name="gain" description="Channel gain selector: 14, 25, 7.8, 4.7 mV/fC (0 - 3)" type="u8" range="0,1,2,3" init-value="0" is-not-null="yes"/>
   <attribute name="peak_time" description="Channel peak time selector: 1.0, 0.5, 3, 2 us (0 - 3)" type="u8" range="0,1,2,3" init-value="3" is-not-null="yes"/>
@@ -155,6 +155,10 @@
   <attribute name="pulser" description="True if the calibration pulser should be enabled" type="bool" init-value="false" is-not-null="yes"/>
   <attribute name="detector_type" description="Detector type selector: WIB default (0), upper APA (1), lower APA (2), CRP (3)" type="u8" range="0,1,2,3" init-value="0" is-not-null="yes"/>
   <attribute name="adc_test_pattern" description="True if the COLDADC test pattern should be enabled" type="bool" init-value="false" is-not-null="yes"/>
+  <attribute name="enabled_femb0" description="Enable FEMB 0" type="bool" init-value="true" is-not-null="yes"/>
+  <attribute name="enabled_femb1" description="Enable FEMB 1" type="bool" init-value="true" is-not-null="yes"/>
+  <attribute name="enabled_femb2" description="Enable FEMB 2" type="bool" init-value="true" is-not-null="yes"/>
+  <attribute name="enabled_femb3" description="Enable FEMB 3" type="bool" init-value="true" is-not-null="yes"/>
   <relationship name="femb0" description="Settings for FEMB in slot 0" class-type="FEMBSettings" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <relationship name="femb1" description="Settings for FEMB in slot 1" class-type="FEMBSettings" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <relationship name="femb2" description="Settings for FEMB in slot 2" class-type="FEMBSettings" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>

--- a/schema/appmodel/wiec.schema.xml
+++ b/schema/appmodel/wiec.schema.xml
@@ -102,7 +102,7 @@
  </class>
 
  <class name="FEMBSettings">
-  <!-- <attribute name="enabled" description="True of FEMB should be configured and read out by WIB" type="bool" init-value="true" is-not-null="yes"/> -->
+  <attribute name="enabled" description="True of FEMB should be configured and read out by WIB" type="bool" init-value="true" is-not-null="yes"/>
   <attribute name="test_cap" description="Enable the test capacitor" type="bool" init-value="false" is-not-null="yes"/>
   <attribute name="gain" description="Channel gain selector: 14, 25, 7.8, 4.7 mV/fC (0 - 3)" type="u8" range="0,1,2,3" init-value="0" is-not-null="yes"/>
   <attribute name="peak_time" description="Channel peak time selector: 1.0, 0.5, 3, 2 us (0 - 3)" type="u8" range="0,1,2,3" init-value="3" is-not-null="yes"/>
@@ -130,7 +130,12 @@
  <class name="WIBModule">
   <superclass name="DaqModule"/>
   <attribute name="wib_addr" type="string" init-value="tcp://192.168.121.1:1234" is-not-null="yes"/>
+  <attribute name="enabled_femb0" description="Enable FEMB 0" type="bool" init-value="true" is-not-null="yes"/>
+  <attribute name="enabled_femb1" description="Enable FEMB 1" type="bool" init-value="true" is-not-null="yes"/>
+  <attribute name="enabled_femb2" description="Enable FEMB 2" type="bool" init-value="true" is-not-null="yes"/>
+  <attribute name="enabled_femb3" description="Enable FEMB 3" type="bool" init-value="true" is-not-null="yes"/>
   <relationship name="conf" class-type="WIBSettings" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
+
  </class>
 
  <class name="WIBModuleConf">
@@ -155,10 +160,6 @@
   <attribute name="pulser" description="True if the calibration pulser should be enabled" type="bool" init-value="false" is-not-null="yes"/>
   <attribute name="detector_type" description="Detector type selector: WIB default (0), upper APA (1), lower APA (2), CRP (3)" type="u8" range="0,1,2,3" init-value="0" is-not-null="yes"/>
   <attribute name="adc_test_pattern" description="True if the COLDADC test pattern should be enabled" type="bool" init-value="false" is-not-null="yes"/>
-  <attribute name="enabled_femb0" description="Enable FEMB 0" type="bool" init-value="true" is-not-null="yes"/>
-  <attribute name="enabled_femb1" description="Enable FEMB 1" type="bool" init-value="true" is-not-null="yes"/>
-  <attribute name="enabled_femb2" description="Enable FEMB 2" type="bool" init-value="true" is-not-null="yes"/>
-  <attribute name="enabled_femb3" description="Enable FEMB 3" type="bool" init-value="true" is-not-null="yes"/>
   <relationship name="femb0" description="Settings for FEMB in slot 0" class-type="FEMBSettings" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <relationship name="femb1" description="Settings for FEMB in slot 1" class-type="FEMBSettings" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <relationship name="femb2" description="Settings for FEMB in slot 2" class-type="FEMBSettings" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>

--- a/src/DaphneApplication.cpp
+++ b/src/DaphneApplication.cpp
@@ -52,8 +52,8 @@ __reg__("DaphneApplication", [] (const SmartDaqApplication* smartApp,
 
 std::vector<const confmodel::DaqModule*> 
 DaphneApplication::generate_modules(conffwk::Configuration* config,
-				    const std::string& dbfile,
-				    const confmodel::Session* session) const
+                                    const std::string& dbfile,
+                                    const confmodel::Session* session) const
 {
   std::vector<const confmodel::DaqModule*> modules;
 
@@ -87,16 +87,16 @@ DaphneApplication::generate_modules(conffwk::Configuration* config,
     for (const auto* sender : det_senders) {
 
       if ( sender->disabled(*session) ) {
-	TLOG() << "Skipping disabled sender: " << sender->UID();
-	continue;
+        TLOG() << "Skipping disabled sender: " << sender->UID();
+        continue;
       }
       // Check the sender type, must me a FelixDataSender
       const auto* felix_sender = sender->cast<appmodel::FelixDataSender>();
       if (!felix_sender ) {
-	//throw(BadConf(ERS_HERE, fmt::format("DataSender {} is not a appmodel::HermesDataSender", sender->UID())));
-	continue;
-	// MaR: I don't think we should throw here because there can be other connections other than felix
-	// MaR: should we be worried that we assume that a Felix connection is a Daphne?
+        //throw(BadConf(ERS_HERE, fmt::format("DataSender {} is not a appmodel::HermesDataSender", sender->UID())));
+        continue;
+        // MaR: I don't think we should throw here because there can be other connections other than felix
+        // MaR: should we be worried that we assume that a Felix connection is a Daphne?
       }
 
       auto ip = felix_sender -> get_control_host();
@@ -123,7 +123,7 @@ DaphneApplication::generate_modules(conffwk::Configuration* config,
       auto id = raw_ids[i];
       conffwk::ConfigObject channel_obj;
       config->create(dbfile, "DaphneV2Channel",
-		     fmt::format("daphne-{}-channel-{}", slot, id), channel_obj );
+                     fmt::format("daphne-{}-channel-{}", slot, id), channel_obj );
       channel_obj.set_by_val<uint8_t>("channel_id", id);
       channel_obj.set_by_val<uint8_t>("gain", raw_gains[i]);
       channel_obj.set_by_val<uint16_t>("offset", raw_offsets[i]);
@@ -156,7 +156,7 @@ DaphneApplication::generate_modules(conffwk::Configuration* config,
       // create the adc
       conffwk::ConfigObject adc_obj;
       config->create(dbfile, "DaphneV2ADC",
-		     fmt::format("daphne-{}-adc-{}", slot, id), adc_obj);
+                     fmt::format("daphne-{}-adc-{}", slot, id), adc_obj);
       adc_obj.set_by_val<bool>("low_resolution",  raw_adc_res[i] > 0);
       adc_obj.set_by_val<bool>("output_offset_binary",  raw_adc_format[i] > 0 );
       adc_obj.set_by_val<bool>("MSB_first",  raw_adc_SB[i] > 0);
@@ -165,7 +165,7 @@ DaphneApplication::generate_modules(conffwk::Configuration* config,
       // create the lna
       conffwk::ConfigObject lna_obj;
       config->create(dbfile, "DaphneV2LNA",
-		     fmt::format("daphne-{}-lna-{}", slot, id), lna_obj);
+                     fmt::format("daphne-{}-lna-{}", slot, id), lna_obj);
       lna_obj.set_by_val<uint8_t>("clamp",  raw_lna_clamps[i]);
       lna_obj.set_by_val<uint8_t>("gain",  raw_lna_gains[i]);
       lna_obj.set_by_val<bool>("integrator_disable",  raw_lna_integrators[i]>0);
@@ -174,7 +174,7 @@ DaphneApplication::generate_modules(conffwk::Configuration* config,
       // create the pga
       conffwk::ConfigObject pga_obj;
       config->create(dbfile, "DaphneV2PGA",
-		     fmt::format("daphne-{}-pga-{}", slot, id), pga_obj);
+                     fmt::format("daphne-{}-pga-{}", slot, id), pga_obj);
       pga_obj.set_by_val<uint8_t>("lpf_cut_frequency",  raw_pga_cuts[i]);
       pga_obj.set_by_val<bool>("gain",  raw_pga_gains[i]>0);
       pga_obj.set_by_val<bool>("integrator_disable",  raw_pga_integrators[i]>0);
@@ -183,7 +183,7 @@ DaphneApplication::generate_modules(conffwk::Configuration* config,
       // finally create the afe
       conffwk::ConfigObject afe_obj;
       config->create(dbfile, "DaphneV2AFE",
-		     fmt::format("daphne-{}-afe-{}", slot, id),afe_obj );
+                     fmt::format("daphne-{}-afe-{}", slot, id),afe_obj );
       afe_obj.set_by_val<uint8_t>("afe_id", id);
       afe_obj.set_by_val<uint16_t>("attenuator", raw_afe_attenuators[i]);
       afe_obj.set_by_val<uint16_t>("v_bias", raw_afe_biases[i]);
@@ -197,11 +197,11 @@ DaphneApplication::generate_modules(conffwk::Configuration* config,
     
     conffwk::ConfigObject board_obj;
     config->create(dbfile, "DaphneV2BoardConf",
-		   fmt::format("daphne-{}-conf", slot), board_obj);
+                   fmt::format("daphne-{}-conf", slot), board_obj);
     board_obj.set_by_val<uint16_t>("bias_ctrl", raw_conf.at("bias_ctrl"));
     board_obj.set_by_val<uint64_t>("self_trigger_threshold", raw_conf.at("self_trigger_threshold"));
     board_obj.set_by_val<std::vector<uint8_t>>("full_stream_channels",
-					       raw_conf.at("full_stream_channels").get<std::vector<uint8_t>>());
+                                               raw_conf.at("full_stream_channels").get<std::vector<uint8_t>>());
     board_obj.set_by_val<uint64_t>("self_trigger_xcorr", raw_conf.at("self_trigger_xcorr"));
     board_obj.set_by_val<uint32_t>("tp_conf", raw_conf.at("tp_conf"));
     board_obj.set_by_val<uint64_t>("compensator", raw_conf.at("compensator"));

--- a/src/HSIEventToTCApplication.cpp
+++ b/src/HSIEventToTCApplication.cpp
@@ -86,7 +86,7 @@ HSIEventToTCApplication::generate_modules(conffwk::Configuration* confdb,
         connObj.set_by_val<std::string>("connection_type", descriptor->get_connection_type());
         connObj.set_obj("associated_service", &serviceObj);
 
-    	outObj = connObj;
+        outObj = connObj;
     }
   } 
 

--- a/src/TriggerApplication.cpp
+++ b/src/TriggerApplication.cpp
@@ -144,9 +144,9 @@ TriggerApplication::generate_modules(conffwk::Configuration* confdb,
     else if (data_type == "TriggerActivity" || data_type == "TriggerCandidate"){
       tout_net_desc = rule->get_descriptor();
       if (data_type == "TriggerActivity")
-	      handler_name = "tphandler";
+        handler_name = "tphandler";
       else
-	      handler_name = "tahandler";
+        handler_name = "tahandler";
     }
   }
 

--- a/src/WIECApplication.cpp
+++ b/src/WIECApplication.cpp
@@ -16,6 +16,8 @@
 
 #include "appmodel/NWDetDataReceiver.hpp"
 #include "confmodel/NetworkInterface.hpp"
+#include "confmodel/DetectorStream.hpp"
+#include "confmodel/GeoId.hpp"
 
 #include "appmodel/WIECApplication.hpp"
 
@@ -111,10 +113,28 @@ WIECApplication::generate_modules(conffwk::Configuration* config,
 
       // Create WIBModule
       if ( this->get_wib_module_conf() ) {
+
+        bool enable_fembs[4] = {false, false, false, false};
+
+        for ( const auto* sndr : senders ){
+          for ( const auto* res : sndr->get_contains() ) {
+            // Retrieve and use the stream id to calculate the femb_id
+            uint32_t stream_id = res->cast<confmodel::DetectorStream>()->get_geo_id()->get_stream_id();
+            uint32_t femb_id = (stream_id & 0xf) / 2 + 2*((stream_id >> 6) & 0xf);
+            // std::cout << std::format("stream {} -> femb {}", stream_id, femb_id) << std::endl;
+
+            // Enable the femb if any of the associated streams is enabld
+            enable_fembs[femb_id] |= !det_stream->disabled(*session);
+          }
+        }
         conffwk::ConfigObject wib_obj;
         std::string wib_uid = fmt::format("wib-ctrl-{}-{}", this->UID(), ctrlhost);
         config->create(dbfile, "WIBModule", wib_uid, wib_obj);
         wib_obj.set_by_val<std::string>("wib_addr", fmt::format("{}://{}:{}", this->get_wib_module_conf()->get_communication_type(), ctrlhost, this->get_wib_module_conf()->get_communication_port()));
+        wib_obj.set_by_val<bool>("enabled_femb0", enable_fembs[0]);
+        wib_obj.set_by_val<bool>("enabled_femb1", enable_fembs[1]);
+        wib_obj.set_by_val<bool>("enabled_femb2", enable_fembs[2]);
+        wib_obj.set_by_val<bool>("enabled_femb3", enable_fembs[3]);
         wib_obj.set_obj("conf", &this->get_wib_module_conf()->get_settings()->config_object());
         modules.push_back(config->get<appmodel::WIBModule>(wib_obj));
       }

--- a/src/WIECApplication.cpp
+++ b/src/WIECApplication.cpp
@@ -93,8 +93,8 @@ WIECApplication::generate_modules(conffwk::Configuration* config,
     for (const auto* sender : det_senders) {
 
       if ( sender->disabled(*session) ) {
-	TLOG() << "Skipping disabled sender: " << sender->UID();
-	continue;
+        TLOG() << "Skipping disabled sender: " << sender->UID();
+        continue;
       }
       
       // Check the sender type, must me a HermesSender

--- a/src/WIECApplication.cpp
+++ b/src/WIECApplication.cpp
@@ -116,14 +116,18 @@ WIECApplication::generate_modules(conffwk::Configuration* config,
 
         bool enable_fembs[4] = {false, false, false, false};
 
-        for ( const auto* sndr : senders ){
-          for ( const auto* res : sndr->get_contains() ) {
-            // Retrieve and use the stream id to calculate the femb_id
-            uint32_t stream_id = res->cast<confmodel::DetectorStream>()->get_geo_id()->get_stream_id();
+        for ( const auto* sender : senders ){
+          for ( const auto* res : sender->get_contains() ) {
+            // Loop over streams for this sender
+            const auto* det_stream = res->cast<confmodel::DetectorStream>();
+            // Retrieve stream_id and calculate the femb_id
+            uint32_t stream_id = det_stream->get_geo_id()->get_stream_id();
             uint32_t femb_id = (stream_id & 0xf) / 2 + 2*((stream_id >> 6) & 0xf);
+
             // std::cout << std::format("stream {} -> femb {}", stream_id, femb_id) << std::endl;
 
             // Enable the femb if any of the associated streams is enabld
+            // Senders in this senders list should be enabled, but better safe than sorry.
             enable_fembs[femb_id] |= !det_stream->disabled(*session);
           }
         }


### PR DESCRIPTION
enable_femb* attributes have been added to WIBModule configuration class to support FEMB masking based on the masking of the associated detector streams.
This PR uses the new flags to enable/disable the FEMBs in or with the FEMB enable flag in the FEMBSetting object.

To be used with https://github.com/DUNE-DAQ/wibmod/pull/60 

