### PR TITLE
Simplified genmodules signature

### DIFF
--- a/docs/SmartDaqApplication.md
+++ b/docs/SmartDaqApplication.md
@@ -4,7 +4,7 @@ The SmartDaqApplication class allows for automatic creation of modules and conne
 
 ## Writing a new SmartDaqApplication
 
-SmartDaqApplications implement the `std::vector<const confmodel::DaqModule*> generate_modules(conffwk::Configuration*, const std::string&, const comnfmodel::Session*)` method, which is responsible for generating a set of modules and connection objects. Each SmartDaqApplication has a UID from the configuration.
+SmartDaqApplications implement the `std::vector<const confmodel::DaqModule*> generate_modules(const comnfmodel::Session*)` method, which is responsible for generating a set of modules and connection objects. Each SmartDaqApplication has a UID from the configuration.
 
 This section will use the "[DFOApplication](https://github.com/DUNE-DAQ/appmodel/blob/develop/src/DFOApplication.cpp)" SmartDaqApplication as an example.
 
@@ -13,20 +13,6 @@ This section will use the "[DFOApplication](https://github.com/DUNE-DAQ/appmodel
 `ConfigObjectFactory` is an helper class to simplify the creation of `appfwk` configuration objects in `SmartApplication`.
 Once instantiated at the start of `generate_modules`, it offers a set of methods to facilitate the creation of configurarion objects, queues and network connections.
 
-### Boilerplate
-
-The following code must be in your source file to allow the system to instantiate your SmartDaqApplication correctly. The first parameter should be changed to match your SmartDaqApplication class name.
-```C++
-static ModuleFactory::Registrator __reg__("DFOApplication",
-                                          [](const SmartDaqApplication* smartApp,
-                                             conffwk::Configuration* confdb,
-                                             const std::string& dbfile,
-                                             const confmodel::Session* session) -> ModuleFactory::ReturnType {
-                                            auto app = smartApp->cast<DFOApplication>();
-                                            return app->generate_modules(confdb, dbfile, session);
-                                          });
-
-```
 
 ### Creating a module
 
@@ -47,7 +33,7 @@ Here, it is important to understand the DFOApplication schema definition:
   <superclass name="SmartDaqApplication"/>
   <relationship name="dfo" class-type="DFOConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <method name="generate_modules" description="Generate DaqModule dal objects for streams of the application on the fly">
-   <method-implementation language="c++" prototype="std::vector&lt;const dunedaq::confmodel::DaqModule*&gt; generate_modules(conffwk::Configuration*, const std::string&amp;, const confmodel::Session*) const override" body=""/>
+   <method-implementation language="c++" prototype="std::vector&lt;const dunedaq::confmodel::DaqModule*&gt; generate_modules(const confmodel::Session*) const override" body=""/>
   </method>
  </class>
 ```

--- a/pybindsrc/dal_methods.cpp
+++ b/pybindsrc/dal_methods.cpp
@@ -50,10 +50,7 @@ namespace dunedaq::appmodel::python {
   // }
 
   std::vector<ObjectLocator>
-  smart_dap_application_generate_modules(const conffwk::Configuration& confdb,
-                                const std::string& dbfile,
-                                const std::string& app_id,
-                                const std::string& session_id)
+  smart_dap_application_generate_modules(const conffwk::Configuration& confdb, const std::string& app_id, const std::string& session_id)
   {
     auto app =
       const_cast<conffwk::Configuration&>(confdb).get<appmodel::SmartDaqApplication>(app_id);
@@ -61,7 +58,7 @@ namespace dunedaq::appmodel::python {
       const_cast<conffwk::Configuration&>(confdb).get<confmodel::Session>(session_id);
 
     std::vector<ObjectLocator> mods;
-    for (auto mod : app->generate_modules(const_cast<conffwk::Configuration*>(&confdb), dbfile, session)) {
+    for (auto mod : app->generate_modules(session)) {
       mods.push_back({mod->UID(),mod->class_name()});
     }
     return mods;

--- a/python/appmodel/__init__.py
+++ b/python/appmodel/__init__.py
@@ -7,7 +7,7 @@ class UnknownGeneratorException(Exception):
 
 def generate_modules(confdb, app, session):
 
-    mods = smart_dap_application_generate_modules(confdb._obj, confdb.active_database, app.id, session.id)
+    mods = smart_dap_application_generate_modules(confdb._obj, app.id, session.id)
 
     return [confdb.get_dal(m.class_name, m.id) for m in mods]
 

--- a/schema/appmodel/PDS.schema.xml
+++ b/schema/appmodel/PDS.schema.xml
@@ -93,7 +93,7 @@
   <superclass name="ResourceSetAND"/>
   <relationship name="configuration" class-type="DaphneConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <method name="generate_modules" description="Generate DaqModule dal objects for streams of the application on the fly">
-   <method-implementation language="c++" prototype="std::vector&lt;const dunedaq::confmodel::DaqModule*&gt; generate_modules(conffwk::Configuration*, const std::string&amp;, const confmodel::Session*) const override" body=""/>
+   <method-implementation language="c++" prototype="std::vector&lt;const dunedaq::confmodel::DaqModule*&gt; generate_modules(const confmodel::Session*) const override" body=""/>
   </method>
  </class>
 

--- a/schema/appmodel/application.schema.xml
+++ b/schema/appmodel/application.schema.xml
@@ -94,7 +94,7 @@
   <relationship name="data_writers" class-type="DataWriterConf" low-cc="one" high-cc="many" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <relationship name="uses" class-type="DFHWConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <method name="generate_modules" description="Generate DaqModule dal objects for streams of the application on the fly">
-   <method-implementation language="c++" prototype="std::vector&lt;const dunedaq::confmodel::DaqModule*&gt; generate_modules(conffwk::Configuration*, const std::string&amp;, const confmodel::Session*) const override" body=""/>
+   <method-implementation language="c++" prototype="std::vector&lt;const dunedaq::confmodel::DaqModule*&gt; generate_modules(const confmodel::Session*) const override" body=""/>
   </method>
  </class>
 
@@ -106,7 +106,7 @@
   <superclass name="SmartDaqApplication"/>
   <relationship name="dfo" class-type="DFOConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <method name="generate_modules" description="Generate DaqModule dal objects for streams of the application on the fly">
-   <method-implementation language="c++" prototype="std::vector&lt;const dunedaq::confmodel::DaqModule*&gt; generate_modules(conffwk::Configuration*, const std::string&amp;, const confmodel::Session*) const override" body=""/>
+   <method-implementation language="c++" prototype="std::vector&lt;const dunedaq::confmodel::DaqModule*&gt; generate_modules(const confmodel::Session*) const override" body=""/>
   </method>
  </class>
 
@@ -214,7 +214,7 @@
   <superclass name="SmartDaqApplication"/>
   <attribute name="application_name" type="string" init-value="daq_application" is-not-null="yes"/>
   <method name="generate_modules" description="Generate daq module dal objects for streams of the FakeDataApplication on the fly">
-   <method-implementation language="c++" prototype="std::vector&lt;const dunedaq::confmodel::DaqModule*&gt; generate_modules(conffwk::Configuration*, const std::string&amp;, const confmodel::Session*) const override" body=""/>
+   <method-implementation language="c++" prototype="std::vector&lt;const dunedaq::confmodel::DaqModule*&gt; generate_modules(const confmodel::Session*) const override" body=""/>
   </method>
  </class>
 
@@ -243,7 +243,7 @@
   <relationship name="link_handler" class-type="DataHandlerConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <relationship name="generator" class-type="FakeHSIEventGeneratorConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <method name="generate_modules" description="Generate DaqModule dal objects for streams of the application on the fly">
-   <method-implementation language="c++" prototype="std::vector&lt;const dunedaq::confmodel::DaqModule*&gt; generate_modules(conffwk::Configuration*, const std::string&amp;, const confmodel::Session*) const override" body=""/>
+   <method-implementation language="c++" prototype="std::vector&lt;const dunedaq::confmodel::DaqModule*&gt; generate_modules(const confmodel::Session*) const override" body=""/>
   </method>
  </class>
 
@@ -279,7 +279,7 @@
   <relationship name="link_handler" class-type="DataHandlerConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <relationship name="generator" class-type="HSIReadoutConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <method name="generate_modules" description="Generate DaqModule dal objects for streams of the application on the fly">
-   <method-implementation language="c++" prototype="std::vector&lt;const dunedaq::confmodel::DaqModule*&gt; generate_modules(conffwk::Configuration*, const std::string&amp;, const confmodel::Session*) const override" body=""/>
+   <method-implementation language="c++" prototype="std::vector&lt;const dunedaq::confmodel::DaqModule*&gt; generate_modules(const confmodel::Session*) const override" body=""/>
   </method>
  </class>
 
@@ -378,7 +378,7 @@
   <relationship name="data_reader" class-type="DataReaderConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <relationship name="data_recorder" class-type="DataRecorderConf" low-cc="zero" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <method name="generate_modules" description="Generate daq module dal objects for streams of thie ReadoutApplication on the fly">
-   <method-implementation language="c++" prototype="std::vector&lt;const dunedaq::confmodel::DaqModule*&gt; generate_modules(conffwk::Configuration*, const std::string&amp;, const confmodel::Session*) const override" body=""/>
+   <method-implementation language="c++" prototype="std::vector&lt;const dunedaq::confmodel::DaqModule*&gt; generate_modules(const confmodel::Session*) const override" body=""/>
   </method>
  </class>
 
@@ -411,7 +411,7 @@
   <relationship name="network_rules" class-type="NetworkConnectionRule" low-cc="zero" high-cc="many" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <relationship name="action_plans" class-type="ActionPlan" low-cc="zero" high-cc="many" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <method name="generate_modules" description="">
-   <method-implementation language="c++" prototype="virtual std::vector&lt;const dunedaq::confmodel::DaqModule*&gt; generate_modules(conffwk::Configuration*, const std::string&amp;, const confmodel::Session*) const" body=""/>
+   <method-implementation language="c++" prototype="virtual std::vector&lt;const dunedaq::confmodel::DaqModule*&gt; generate_modules(const confmodel::Session*) const" body=""/>
   </method>
   <method name="construct_commandline_parameters" description="get the command line parameters for this application">
    <method-implementation language="c++" prototype=" const std::vector&lt;std::string&gt; construct_commandline_parameters(const conffwk::Configuration&amp; confdb, const dunedaq::confmodel::Session* session) const" body="BEGIN_HEADER_PROLOGUE&#xA;#include &quot;confmodel/util.hpp&quot;&#xA;END_HEADER_PROLOGUE"/>
@@ -424,7 +424,7 @@
   <attribute name="application_name" type="string" init-value="daq_application" is-not-null="yes"/>
   <relationship name="data_writers" class-type="SocketDataWriterConf" low-cc="one" high-cc="many" is-composite="no" is-exclusive="no" is-dependent="no"/>  
   <method name="generate_modules" description="Generate daq module dal objects for streams of the SocketSenderApplication on the fly">
-   <method-implementation language="c++" prototype="std::vector&lt;const dunedaq::confmodel::DaqModule*&gt; generate_modules(conffwk::Configuration*, const std::string&amp;, const confmodel::Session*) const override" body=""/>
+   <method-implementation language="c++" prototype="std::vector&lt;const dunedaq::confmodel::DaqModule*&gt; generate_modules(const confmodel::Session*) const override" body=""/>
   </method>
  </class>
 
@@ -454,7 +454,7 @@
   <superclass name="SmartDaqApplication"/>
   <relationship name="tp_writer" class-type="TPStreamWriterConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <method name="generate_modules" description="Generate dal objects for streams of thie ReadoutApplication on the fly">
-   <method-implementation language="c++" prototype="std::vector&lt;const dunedaq::confmodel::DaqModule*&gt; generate_modules(conffwk::Configuration*, const std::string&amp;, const confmodel::Session*) const override" body=""/>
+   <method-implementation language="c++" prototype="std::vector&lt;const dunedaq::confmodel::DaqModule*&gt; generate_modules(const confmodel::Session*) const override" body=""/>
   </method>
  </class>
 

--- a/schema/appmodel/trigger.schema.xml
+++ b/schema/appmodel/trigger.schema.xml
@@ -136,7 +136,7 @@
   <superclass name="SmartDaqApplication"/>
   <relationship name="hsevent_to_tc_conf" class-type="HSI2TCTranslatorConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <method name="generate_modules" description="Generate daq module dal objects for HSIEventToTCApplication on the fly">
-   <method-implementation language="c++" prototype="std::vector&lt;const dunedaq::confmodel::DaqModule*&gt; generate_modules(conffwk::Configuration*, const std::string&amp;, const confmodel::Session*) const override" body=""/>
+   <method-implementation language="c++" prototype="std::vector&lt;const dunedaq::confmodel::DaqModule*&gt; generate_modules(const confmodel::Session*) const override" body=""/>
   </method>
  </class>
 
@@ -153,7 +153,7 @@
   <relationship name="mlt_conf" class-type="MLTConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <relationship name="standalone_candidate_maker_confs" class-type="StandaloneTCMakerConf" low-cc="zero" high-cc="many" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <method name="generate_modules" description="Generate daq module dal objects for MLTApplication on the fly">
-   <method-implementation language="c++" prototype="std::vector&lt;const dunedaq::confmodel::DaqModule*&gt; generate_modules(conffwk::Configuration*, const std::string&amp;, const confmodel::Session*) const override" body=""/>
+   <method-implementation language="c++" prototype="std::vector&lt;const dunedaq::confmodel::DaqModule*&gt; generate_modules(const confmodel::Session*) const override" body=""/>
   </method>
  </class>
 
@@ -396,7 +396,7 @@
   <relationship name="data_subscriber" class-type="DataReaderConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <relationship name="trigger_inputs_handler" class-type="DataHandlerConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <method name="generate_modules" description="Generate daq module dal objects for streams of thie TriggerApplication on the fly">
-   <method-implementation language="c++" prototype="std::vector&lt;const dunedaq::confmodel::DaqModule*&gt; generate_modules(conffwk::Configuration*, const std::string&amp;, const confmodel::Session*) const override" body=""/>
+   <method-implementation language="c++" prototype="std::vector&lt;const dunedaq::confmodel::DaqModule*&gt; generate_modules(const confmodel::Session*) const override" body=""/>
   </method>
  </class>
 

--- a/schema/appmodel/wiec.schema.xml
+++ b/schema/appmodel/wiec.schema.xml
@@ -174,7 +174,7 @@
   <relationship name="wib_module_conf" class-type="WIBModuleConf" low-cc="zero" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <relationship name="hermes_module_conf" class-type="HermesModuleConf" low-cc="zero" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <method name="generate_modules" description="Generate DaqModule dal objects for streams of the application on the fly">
-   <method-implementation language="c++" prototype="std::vector&lt;const dunedaq::confmodel::DaqModule*&gt; generate_modules(conffwk::Configuration*, const std::string&amp;, const confmodel::Session*) const override" body=""/>
+   <method-implementation language="c++" prototype="std::vector&lt;const dunedaq::confmodel::DaqModule*&gt; generate_modules(const confmodel::Session*) const override" body=""/>
   </method>
  </class>
 

--- a/src/ConfigObjectFactory.hpp
+++ b/src/ConfigObjectFactory.hpp
@@ -65,6 +65,16 @@ public:
 
   [[nodiscard]] conffwk::ConfigObject
   create_net_obj(const NetworkConnectionDescriptor* ndesc) const;
+
+  template<class T>
+  const T* get_dal(std::string uid){
+    return m_config->get<T>(uid);
+  }
+
+  template<class T>
+  const T* get_dal(conffwk::ConfigObject& obj){
+    return m_config->get<T>(obj);
+  }
 };
 
 } // namespace dunedaq::appmodel

--- a/src/DFApplication.cpp
+++ b/src/DFApplication.cpp
@@ -145,14 +145,12 @@ fill_sourceid_object_from_app(const ConfigObjectFactory& obj_fac,
 }
 
 std::vector<const confmodel::DaqModule*>
-DFApplication::generate_modules(conffwk::Configuration* confdb,
-                                const std::string& dbfile,
-                                const confmodel::Session* session) const
+DFApplication::generate_modules(const confmodel::Session* session) const
 {
+
+  ConfigObjectFactory obj_fac(this);
+
   std::vector<const confmodel::DaqModule*> modules;
-
-  const auto obj_fac = ConfigObjectFactory(this);
-
 
   // Containers for module specific config objects for output/input
   // Prepare TRB output objects
@@ -276,7 +274,7 @@ DFApplication::generate_modules(conffwk::Configuration* confdb,
   trbObj.set_objs("outputs", trbOutputObjs);
   trbObj.set_objs("request_connections", trbSidNetObjs);
   // Push TRB Module Object from confdb
-  modules.push_back(confdb->get<TRBModule>(trbUid));
+  modules.push_back(obj_fac.get_dal<TRBModule>(trbUid));
 
   // Get DataWriterModule Config Object (only one for now, maybe more later?)
   auto dwrConfs = get_data_writers();
@@ -297,7 +295,7 @@ DFApplication::generate_modules(conffwk::Configuration* confdb,
     dwrObj.set_objs("inputs", { &trQueueObj });
     dwrObj.set_objs("outputs", { &tokenNetObj });
     // Push DataWriterModule Module Object from confdb
-    modules.push_back(confdb->get<DataWriterModule>(dwrUid));
+    modules.push_back(obj_fac.get_dal<DataWriterModule>(dwrUid));
     ++dw_idx;
   }
 

--- a/src/DFOApplication.cpp
+++ b/src/DFOApplication.cpp
@@ -33,13 +33,11 @@ namespace dunedaq {
 namespace appmodel {
 
 std::vector<const confmodel::DaqModule*>
-DFOApplication::generate_modules(conffwk::Configuration* confdb,
-                                 const std::string& dbfile,
-                                 const confmodel::Session* session) const
+DFOApplication::generate_modules(const confmodel::Session* session) const
 {
   std::vector<const confmodel::DaqModule*> modules;
 
-  const auto obj_fac = ConfigObjectFactory(this);
+  ConfigObjectFactory obj_fac(this);
 
 
   std::string dfoUid("DFO-" + UID());
@@ -118,7 +116,7 @@ DFOApplication::generate_modules(conffwk::Configuration* confdb,
   dfoObj.set_objs("outputs", output_conns);
 
   // Add to our list of modules to return
-  modules.push_back(confdb->get<DFOModule>(dfoUid));
+  modules.push_back(obj_fac.get_dal<DFOModule>(dfoUid));
 
   return modules;
 }

--- a/src/DTSHSIApplication.cpp
+++ b/src/DTSHSIApplication.cpp
@@ -35,9 +35,7 @@ namespace dunedaq {
 namespace appmodel {
 
 std::vector<const confmodel::DaqModule*>
-DTSHSIApplication::generate_modules(conffwk::Configuration* confdb,
-                                     const std::string& dbfile,
-                                     const confmodel::Session* /*session*/) const
+DTSHSIApplication::generate_modules(const confmodel::Session* /*session*/) const
 {
   ConfigObjectFactory obj_fac(this);
   
@@ -119,7 +117,7 @@ DTSHSIApplication::generate_modules(conffwk::Configuration* confdb,
   conffwk::ConfigObject faNetObj = obj_fac.create_net_obj(dlhReqInputNetDesc, UID());
   dlhObj.set_objs("inputs", { &queueObj, &faNetObj });
 
-  modules.push_back(confdb->get<DataHandlerModule>(uid));
+  modules.push_back(obj_fac.get_dal<DataHandlerModule>(uid));
 
   auto hsiServiceObj = hsiNetDesc->get_associated_service()->config_object();
   conffwk::ConfigObject hsiNetObj = obj_fac.create_net_obj(hsiNetDesc, "");
@@ -129,7 +127,7 @@ DTSHSIApplication::generate_modules(conffwk::Configuration* confdb,
   hsiObj.set_obj("configuration", &rdrConf->config_object());
   hsiObj.set_objs("outputs", { &queueObj, &hsiNetObj });
 
-  modules.push_back(confdb->get<HSIReadout>(genuid));
+  modules.push_back(obj_fac.get_dal<HSIReadout>(genuid));
 
   return modules;
 }

--- a/src/DaphneApplication.cpp
+++ b/src/DaphneApplication.cpp
@@ -42,11 +42,13 @@ namespace dunedaq {
 namespace appmodel {
   
 std::vector<const confmodel::DaqModule*> 
-DaphneApplication::generate_modules(conffwk::Configuration* config,
-                                    const std::string& dbfile,
-                                    const confmodel::Session* session) const
+DaphneApplication::generate_modules(
+                                    const confmodel::Session* session
+                                  ) const
 {
-  const auto obj_fac = ConfigObjectFactory(this);
+  ConfigObjectFactory obj_fac(this);
+  conffwk::Configuration* config = &this->configuration();
+  const std::string& dbfile = this->config_object().contained_in();
 
   std::vector<const confmodel::DaqModule*> modules;
 
@@ -138,7 +140,7 @@ DaphneApplication::generate_modules(conffwk::Configuration* config,
       channel_obj.set_by_val<uint8_t>("gain", raw_gains[i]);
       channel_obj.set_by_val<uint16_t>("offset", raw_offsets[i]);
       channel_obj.set_by_val<uint16_t>("trim", raw_trims[i]);
-      auto ch = config->get<appmodel::DaphneV2Channel>(channel_obj);
+      auto ch = obj_fac.get_dal<appmodel::DaphneV2Channel>(channel_obj);
       channels.push_back(& ch -> config_object());
     }
     
@@ -170,7 +172,7 @@ DaphneApplication::generate_modules(conffwk::Configuration* config,
       adc_obj.set_by_val<bool>("low_resolution",  raw_adc_res[i] > 0);
       adc_obj.set_by_val<bool>("output_offset_binary",  raw_adc_format[i] > 0 );
       adc_obj.set_by_val<bool>("MSB_first",  raw_adc_SB[i] > 0);
-      auto adc = config->get<appmodel::DaphneV2ADC>(adc_obj);
+      auto adc = obj_fac.get_dal<appmodel::DaphneV2ADC>(adc_obj);
       
       // create the lna
       conffwk::ConfigObject lna_obj;
@@ -179,7 +181,7 @@ DaphneApplication::generate_modules(conffwk::Configuration* config,
       lna_obj.set_by_val<uint8_t>("clamp",  raw_lna_clamps[i]);
       lna_obj.set_by_val<uint8_t>("gain",  raw_lna_gains[i]);
       lna_obj.set_by_val<bool>("integrator_disable",  raw_lna_integrators[i]>0);
-      auto lna = config->get<appmodel::DaphneV2LNA>(lna_obj);
+      auto lna = obj_fac.get_dal<appmodel::DaphneV2LNA>(lna_obj);
       
       // create the pga
       conffwk::ConfigObject pga_obj;
@@ -188,7 +190,7 @@ DaphneApplication::generate_modules(conffwk::Configuration* config,
       pga_obj.set_by_val<uint8_t>("lpf_cut_frequency",  raw_pga_cuts[i]);
       pga_obj.set_by_val<bool>("gain",  raw_pga_gains[i]>0);
       pga_obj.set_by_val<bool>("integrator_disable",  raw_pga_integrators[i]>0);
-      auto pga = config->get<appmodel::DaphneV2PGA>(pga_obj);
+      auto pga = obj_fac.get_dal<appmodel::DaphneV2PGA>(pga_obj);
       
       // finally create the afe
       conffwk::ConfigObject afe_obj;
@@ -200,7 +202,7 @@ DaphneApplication::generate_modules(conffwk::Configuration* config,
       afe_obj.set_obj("adc", & adc -> config_object() );
       afe_obj.set_obj("lna", & lna -> config_object() );
       afe_obj.set_obj("pga", & pga -> config_object() );
-      auto afe = config->get<appmodel::DaphneV2AFE>(afe_obj);
+      auto afe = obj_fac.get_dal<appmodel::DaphneV2AFE>(afe_obj);
       afes.push_back( & afe-> config_object());
     }
     
@@ -223,7 +225,7 @@ DaphneApplication::generate_modules(conffwk::Configuration* config,
     board_obj.set_objs("active_afes", afes);
     board_obj.set_obj("default_channel", & daphne_conf->get_default_v2_settings()->get_default_channel()->config_object());
     board_obj.set_obj("default_afe", & daphne_conf->get_default_v2_settings()->get_default_afe()->config_object());
-    auto conf = config->get<appmodel::DaphneV2BoardConf>(board_obj);
+    auto conf = obj_fac.get_dal<appmodel::DaphneV2BoardConf>(board_obj);
     
     conffwk::ConfigObject module_obj;
     std::string module_name = fmt::format("controller-{}", slot);
@@ -232,7 +234,7 @@ DaphneApplication::generate_modules(conffwk::Configuration* config,
     module_obj.set_obj("daphne_conf", & daphne_conf -> config_object() );
     module_obj.set_obj("board_conf", & conf -> config_object() );
     
-    auto module = config->get<appmodel::DaphneV2ControllerModule>(module_obj);
+    auto module = obj_fac.get_dal<appmodel::DaphneV2ControllerModule>(module_obj);
     modules.push_back(module);
     
   } // ips

--- a/src/FakeDataApplication.cpp
+++ b/src/FakeDataApplication.cpp
@@ -41,15 +41,13 @@ namespace dunedaq {
 namespace appmodel {
 
 std::vector<const confmodel::DaqModule*>
-FakeDataApplication::generate_modules(conffwk::Configuration* confdb,
-                                      const std::string& dbfile,
-                                      const confmodel::Session* session) const
+FakeDataApplication::generate_modules(const confmodel::Session* session) const
 {
   // oks::OksFile::set_nolock_mode(true);
 
   std::vector<const confmodel::DaqModule*> modules;
 
-  const auto obj_fac = ConfigObjectFactory(this);
+  ConfigObjectFactory obj_fac(this);
 
 
   // Process the queue rules looking for inputs to our DL/TP handler modules
@@ -124,12 +122,12 @@ FakeDataApplication::generate_modules(conffwk::Configuration* confdb,
     auto reqQueueObj = obj_fac.create_queue_sid_obj(dlhReqInputQDesc, id);
 
     // Add the requessts queue dal pointer to the outputs of the FragmentAggregatorModule
-    faOutputQueues.push_back(confdb->get<confmodel::Connection>(
+    faOutputQueues.push_back(obj_fac.get_dal<confmodel::Connection>(
                                dlhReqInputQDesc->get_uid_base() + std::to_string(id)));
 
     dlhObj.set_objs("inputs", { &reqQueueObj });
 
-    modules.push_back(confdb->get<FakeDataProdModule>(uid));
+    modules.push_back(obj_fac.get_dal<FakeDataProdModule>(uid));
   }
 
   // Finally create Fragment Aggregator
@@ -148,7 +146,7 @@ FakeDataApplication::generate_modules(conffwk::Configuration* confdb,
   faObj.set_objs("inputs", { &faNetObj, &faQueueObj });
   faObj.set_objs("outputs", qObjs);
 
-  modules.push_back(confdb->get<FragmentAggregatorModule>(faUid));
+  modules.push_back(obj_fac.get_dal<FragmentAggregatorModule>(faUid));
 
   // oks::OksFile::set_nolock_mode(false);
   return modules;

--- a/src/FakeHSIApplication.cpp
+++ b/src/FakeHSIApplication.cpp
@@ -40,13 +40,11 @@ namespace dunedaq {
 namespace appmodel {
 
 std::vector<const confmodel::DaqModule*>
-FakeHSIApplication::generate_modules(conffwk::Configuration* confdb,
-                                     const std::string& dbfile,
-                                     const confmodel::Session* session) const
+FakeHSIApplication::generate_modules(const confmodel::Session* session) const
 {
   std::vector<const confmodel::DaqModule*> modules;
 
-  const auto obj_fac = ConfigObjectFactory(this);
+  ConfigObjectFactory obj_fac(this);
 
 
   auto dlhConf = get_link_handler();
@@ -151,7 +149,7 @@ FakeHSIApplication::generate_modules(conffwk::Configuration* confdb,
 
   dlhObj.set_objs("inputs", { &queueObj, &faNetObj });
 
-  modules.push_back(confdb->get<DataHandlerModule>(uid));
+  modules.push_back(obj_fac.get_dal<DataHandlerModule>(uid));
 
   auto hsiServiceObj = hsiNetDesc->get_associated_service()->config_object();
   conffwk::ConfigObject hsiNetObj = obj_fac.create_net_obj(hsiNetDesc, "");
@@ -162,7 +160,7 @@ FakeHSIApplication::generate_modules(conffwk::Configuration* confdb,
   fakehsiObj.set_obj("configuration", &rdrConf->config_object());
   fakehsiObj.set_objs("outputs", { &queueObj, &hsiNetObj });
 
-  modules.push_back(confdb->get<FakeHSIEventGeneratorModule>(genuid));
+  modules.push_back(obj_fac.get_dal<FakeHSIEventGeneratorModule>(genuid));
 
   return modules;
 }

--- a/src/HSIEventToTCApplication.cpp
+++ b/src/HSIEventToTCApplication.cpp
@@ -32,14 +32,12 @@ namespace dunedaq {
 namespace appmodel {
 
 std::vector<const confmodel::DaqModule*> 
-HSIEventToTCApplication::generate_modules(conffwk::Configuration* confdb,
-                                     const std::string& dbfile,
-                                     const confmodel::Session* /*session*/) const
+HSIEventToTCApplication::generate_modules(const confmodel::Session* /*session*/) const
 {
+
+  ConfigObjectFactory obj_fac(this);
+  
   std::vector<const confmodel::DaqModule*> modules;
-
-  const auto obj_fac = ConfigObjectFactory(this);
-
 
   std::string hstcUid("module-" + UID());
   TLOG_DEBUG(7) << "creating OKS configuration object for the DataSubscriberModule class ";
@@ -78,7 +76,7 @@ HSIEventToTCApplication::generate_modules(conffwk::Configuration* confdb,
   hstcObj.set_objs("outputs", {&outObj});
 
   // Add to our list of modules to return
-  modules.push_back(confdb->get<DataSubscriberModule>(hstcUid));
+  modules.push_back(obj_fac.get_dal<DataSubscriberModule>(hstcUid));
 
   return modules;
 }

--- a/src/MLTApplication.cpp
+++ b/src/MLTApplication.cpp
@@ -67,17 +67,12 @@ namespace appmodel {
 
 
 std::vector<const confmodel::DaqModule*>
-MLTApplication::generate_modules(conffwk::Configuration* confdb,
-                                 const std::string& dbfile,
-                                 const confmodel::Session* session) const
+MLTApplication::generate_modules(const confmodel::Session* session) const
 {
-
-  TLOG() << "AAAAAA : Calling MLTApplication::generate_modules";
 
   std::vector<const confmodel::DaqModule*> modules;
 
-  const auto obj_fac = ConfigObjectFactory(this);
-
+  ConfigObjectFactory obj_fac(this);
 
   // auto mlt_conf = get_mlt_conf();
   // auto mlt_class = mlt_conf->get_template_for();
@@ -202,7 +197,7 @@ MLTApplication::generate_modules(conffwk::Configuration* confdb,
     generated_tc_conns.push_back(tc_net_gen);
 
     gen_obj.set_objs("outputs", { &generated_tc_conns.back() });
-    modules.push_back(confdb->get<StandaloneTCMakerModule>(gen_conf->UID()));
+    modules.push_back(obj_fac.get_dal<StandaloneTCMakerModule>(gen_conf->UID()));
   }
 
   /**************************************************************
@@ -221,7 +216,7 @@ MLTApplication::generate_modules(conffwk::Configuration* confdb,
   reader_obj.set_objs("outputs", { &input_queue_obj });
   reader_obj.set_obj("configuration", &rdr_conf->config_object());
 
-  modules.push_back(confdb->get<DataSubscriberModule>(reader_uid));
+  modules.push_back(obj_fac.get_dal<DataSubscriberModule>(reader_uid));
 
   /**************************************************************
    * Create the readout map
@@ -407,7 +402,7 @@ MLTApplication::generate_modules(conffwk::Configuration* confdb,
   ti_obj.set_objs("outputs", ti_output_objs);
 
   // Add to our list of modules to return
-  modules.push_back(confdb->get<DataHandlerModule>(ti_uid));
+  modules.push_back(obj_fac.get_dal<DataHandlerModule>(ti_uid));
 
   /**************************************************************
    * Instantiate the MLTModule module
@@ -418,7 +413,7 @@ MLTApplication::generate_modules(conffwk::Configuration* confdb,
   mlt_obj.set_obj("configuration", &(mlt_conf->config_object()));
   mlt_obj.set_objs("inputs", { &output_queue_obj, &ti_net_obj });
   mlt_obj.set_objs("outputs", { &td_net_obj });
-  modules.push_back(confdb->get<MLTModule>(mlt_conf->UID()));
+  modules.push_back(obj_fac.get_dal<MLTModule>(mlt_conf->UID()));
 
   return modules;
 }

--- a/src/ReadoutApplication.cpp
+++ b/src/ReadoutApplication.cpp
@@ -68,13 +68,14 @@ namespace appmodel {
 
 //-----------------------------------------------------------------------------
 std::vector<const confmodel::DaqModule*>
-ReadoutApplication::generate_modules(conffwk::Configuration* config, const std::string& dbfile, const confmodel::Session* session) const
+ReadoutApplication::generate_modules(const confmodel::Session* session) const
 {
 
   TLOG_DEBUG(6) << "Generating modules for application " << this->UID();
 
   ConfigObjectFactory obj_fac(this);
-  
+  // conffwk::Configuration& confdb = this->configuration();
+
   //
   // Extract basic configuration objects
   //
@@ -277,14 +278,14 @@ ReadoutApplication::generate_modules(conffwk::Configuration* config, const std::
     // Create data queues
     for (auto ds : enabled_det_streams) {
       conffwk::ConfigObject queue_obj = obj_fac.create_queue_sid_obj(dlh_input_qdesc, ds);
-      const auto* data_queue = config->get<confmodel::Connection>(queue_obj.UID());
+      const auto* data_queue = obj_fac.get_dal<confmodel::Connection>(queue_obj.UID());
       data_queue_objs.push_back(&data_queue->config_object());
       data_queues_by_sid[ds->get_source_id()] = data_queue;
     }
 
     reader_obj.set_objs("outputs", data_queue_objs);
 
-    modules.push_back(config->get<confmodel::DaqModule>(reader_obj.UID()));
+    modules.push_back(obj_fac.get_dal<confmodel::DaqModule>(reader_obj.UID()));
 
   }
 
@@ -315,10 +316,10 @@ ReadoutApplication::generate_modules(conffwk::Configuration* config, const std::
       tp_queue_obj.set_by_val<uint32_t>("recv_timeout_ms", 50);
       tp_queue_obj.set_by_val<uint32_t>("send_timeout_ms", 1);
 
-      tp_queues.push_back(config->get<confmodel::Connection>(tp_queue_obj.UID()));
+      tp_queues.push_back(obj_fac.get_dal<confmodel::Connection>(tp_queue_obj.UID()));
       // Create tp data requests queue from Fragment Aggregator
       tpreq_queue_obj = obj_fac.create_queue_sid_obj(dlh_reqinput_qdesc, sid->get_sid());
-      req_queues.push_back(config->get<confmodel::Connection>(tpreq_queue_obj.UID()));
+      req_queues.push_back(obj_fac.get_dal<confmodel::Connection>(tpreq_queue_obj.UID()));
 
       // Create the tp(set) publishing service
       conffwk::ConfigObject tp_net_obj = obj_fac.create_net_obj(tp_net_desc, tp_uid);
@@ -329,7 +330,7 @@ ReadoutApplication::generate_modules(conffwk::Configuration* config, const std::
       // Register queues with tp hankder
       tph_obj.set_objs("inputs", { &tp_queue_obj, &tpreq_queue_obj });
       tph_obj.set_objs("outputs", { &tp_net_obj, &ta_net_obj, &frag_queue_obj });
-      modules.push_back(config->get<confmodel::DaqModule>(tph_obj.UID()));
+      modules.push_back(obj_fac.get_dal<confmodel::DaqModule>(tph_obj.UID()));
     }
   }
 
@@ -369,7 +370,7 @@ ReadoutApplication::generate_modules(conffwk::Configuration* config, const std::
 
 
     // Add the requessts queue dal pointer to the outputs of the FragmentAggregatorModule
-    req_queues.push_back(config->get<confmodel::Connection>(req_queue_obj.UID()));
+    req_queues.push_back(obj_fac.get_dal<confmodel::Connection>(req_queue_obj.UID()));
     dlh_ins.push_back(&req_queue_obj);
     dlh_outs.push_back(&frag_queue_obj);
 
@@ -387,7 +388,7 @@ ReadoutApplication::generate_modules(conffwk::Configuration* config, const std::
     dlh_obj.set_objs("inputs", dlh_ins);
     dlh_obj.set_objs("outputs", dlh_outs);
 
-    modules.push_back(config->get<confmodel::DaqModule>(dlh_obj.UID()));
+    modules.push_back(obj_fac.get_dal<confmodel::DaqModule>(dlh_obj.UID()));
   }
 
 
@@ -414,7 +415,7 @@ ReadoutApplication::generate_modules(conffwk::Configuration* config, const std::
       if (data_type == "Fragment") {
         std::string dreqNetUid(descriptor->get_uid_base() + dfapp->UID());
         // conffwk::ConfigObject frag_conn;
-        // config->create(dbfile, "NetworkConnection", dreqNetUid, frag_conn);
+        // confdb.create(dbfile, "NetworkConnection", dreqNetUid, frag_conn);
         auto frag_conn = obj_fac.create("NetworkConnection", dreqNetUid);
 
         frag_conn.set_by_val<std::string>("data_type", descriptor->get_data_type());
@@ -440,7 +441,7 @@ ReadoutApplication::generate_modules(conffwk::Configuration* config, const std::
   frag_aggr.set_objs("inputs", { &fa_net_obj, &frag_queue_obj });
   frag_aggr.set_objs("outputs", fa_output_objs);
 
-  modules.push_back(config->get<confmodel::DaqModule>(frag_aggr.UID()));
+  modules.push_back(obj_fac.get_dal<confmodel::DaqModule>(frag_aggr.UID()));
 
   return modules;
 }

--- a/src/SmartDaqApplication.cpp
+++ b/src/SmartDaqApplication.cpp
@@ -7,9 +7,8 @@ namespace dunedaq {
 namespace appmodel {
 
 std::vector<const dunedaq::confmodel::DaqModule*>
-SmartDaqApplication::generate_modules(conffwk::Configuration* confdb,
-                                      const std::string& dbfile,
-                                      const confmodel::Session* session) const {
+SmartDaqApplication::generate_modules(const confmodel::Session* session) const {
+    // TODO : add warining/assert/exception
 }
 
 const std::vector<std::string> SmartDaqApplication::construct_commandline_parameters(

--- a/src/SocketSenderApplication.cpp
+++ b/src/SocketSenderApplication.cpp
@@ -25,14 +25,11 @@ namespace dunedaq {
 namespace appmodel {
 
 std::vector<const confmodel::DaqModule*>
-SocketSenderApplication::generate_modules(conffwk::Configuration* confdb,
-                                          const std::string& dbfile,
-                                          const confmodel::Session* session) const
+SocketSenderApplication::generate_modules(const confmodel::Session* session) const
 {
+  ConfigObjectFactory obj_fac(this);
+
   std::vector<const confmodel::DaqModule*> modules;
-
-  const auto obj_fac = ConfigObjectFactory(this);
-
 
   //
   // Extract basic configuration objects
@@ -79,7 +76,7 @@ SocketSenderApplication::generate_modules(conffwk::Configuration* confdb,
     writer_obj.set_obj("configuration", &writer_conf->config_object());
     writer_obj.set_objs("connections", d2d_conn_objs);
 
-    modules.push_back(confdb->get<confmodel::DaqModule>(writer_uid));
+    modules.push_back(obj_fac.get_dal<confmodel::DaqModule>(writer_uid));
   }
   return modules;
 }

--- a/src/TPWriterApplication.cpp
+++ b/src/TPWriterApplication.cpp
@@ -34,13 +34,11 @@ namespace dunedaq {
 namespace appmodel {
 
 std::vector<const confmodel::DaqModule*> 
-TPStreamWriterApplication::generate_modules(conffwk::Configuration* confdb,
-                                            const std::string& dbfile,
-                                            const confmodel::Session* /*session*/) const
+TPStreamWriterApplication::generate_modules(const confmodel::Session* /*session*/) const
 {
   std::vector<const confmodel::DaqModule*> modules;
 
-  const auto obj_fac = ConfigObjectFactory(this);
+  ConfigObjectFactory obj_fac(this);
 
 
   auto tpwriterConf = get_tp_writer();
@@ -77,7 +75,7 @@ TPStreamWriterApplication::generate_modules(conffwk::Configuration* confdb,
   tpwrObj.set_obj("configuration", &tpwriterConf->config_object());
   tpwrObj.set_objs("inputs", {&tset_in_net_obj} );
 
-  modules.push_back(confdb->get<TPStreamWriterModule>(tpwrUid));
+  modules.push_back(obj_fac.get_dal<TPStreamWriterModule>(tpwrUid));
 
   return modules;
 }

--- a/src/TriggerApplication.cpp
+++ b/src/TriggerApplication.cpp
@@ -73,14 +73,12 @@ create_network_connection(std::string uid,
 
 
 std::vector<const confmodel::DaqModule*>
-TriggerApplication::generate_modules(conffwk::Configuration* confdb,
-                                     const std::string& dbfile,
-                                     const confmodel::Session* session) const
+TriggerApplication::generate_modules(const confmodel::Session* session) const
 {
 
   std::vector<const confmodel::DaqModule*> modules;
 
-  const auto obj_fac = ConfigObjectFactory(this);
+  ConfigObjectFactory obj_fac(this);
 
   auto ti_conf = get_trigger_inputs_handler();
   auto ti_class = ti_conf->get_template_for();
@@ -220,7 +218,7 @@ TriggerApplication::generate_modules(conffwk::Configuration* confdb,
   ti_obj.set_objs("inputs", {&input_queue_obj, &req_net_obj});
   ti_obj.set_objs("outputs", ti_output_objs);
   // Add to our list of modules to return
-  modules.push_back(confdb->get<DataHandlerModule>(ti_uid));
+  modules.push_back(obj_fac.get_dal<DataHandlerModule>(ti_uid));
 
 
   // Now create the DataSubscriberModule object
@@ -239,7 +237,7 @@ TriggerApplication::generate_modules(conffwk::Configuration* confdb,
   reader_obj.set_objs("outputs", {&input_queue_obj} );
   reader_obj.set_obj("configuration", &rdr_conf->config_object());
 
-  modules.push_back(confdb->get<DataSubscriberModule>(reader_uid));
+  modules.push_back(obj_fac.get_dal<DataSubscriberModule>(reader_uid));
 
   return modules;
 }

--- a/src/WIECApplication.cpp
+++ b/src/WIECApplication.cpp
@@ -40,12 +40,12 @@ namespace dunedaq {
 namespace appmodel {
 
 std::vector<const confmodel::DaqModule*> 
-WIECApplication::generate_modules(conffwk::Configuration* config,
-                                            const std::string& dbfile,
-                                            const confmodel::Session* session) const
+WIECApplication::generate_modules(const confmodel::Session* session) const
 {
   ConfigObjectFactory obj_fac(this);
-
+  conffwk::Configuration* config = &this->configuration();
+  const std::string& dbfile = this->config_object().contained_in();
+  
   std::vector<const confmodel::DaqModule*> modules;
 
   std::map<std::string, std::vector<const appmodel::HermesDataSender*>> ctrlhost_sender_map;

--- a/test/apps/generate_modules_test.cxx
+++ b/test/apps/generate_modules_test.cxx
@@ -67,7 +67,7 @@ int main(int argc, char* argv[]) {
     }
     std::vector<const confmodel::DaqModule*> modules;
     try {
-      modules = daqapp->generate_modules(confdb, dbfile, session);
+      modules = daqapp->generate_modules(session);
     }
     catch (appmodel::BadConf& exc) {
       std::cout << "Caught BadConf exception: " << exc << std::endl;

--- a/test/apps/print_detailed_config_info.cxx
+++ b/test/apps/print_detailed_config_info.cxx
@@ -174,7 +174,7 @@ main(int argc, char* argv[])
       }
       std::vector<const confmodel::DaqModule*> modules;
       try {
-        modules = daqapp->generate_modules(confdb, dbfile, session);
+        modules = daqapp->generate_modules(session);
       } catch (appmodel::BadConf& exc) {
         std::cout << "Caught BadConf exception: " << exc << std::endl;
         exit(-1);


### PR DESCRIPTION
This PR removes the `confdb` and `dbfile` arguments of the `SmartDaqApplication::generate_modules(...)`.
It also adds the `ConfigObjectFactory::get_dal<T>(...)` method  to provide access to `Configuration::get<T>(...)`.