### PR TITLE
JCF: update CMakeLists.txt and cmake/appmodelConfig.cmake.in to build…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,27 +16,23 @@ find_package(fmt REQUIRED)
 
 find_package(Boost COMPONENTS unit_test_framework program_options REQUIRED)
 
-daq_oks_codegen(application.schema.xml hermes.schema.xml fdmodules.schema.xml trigger.schema.xml wiec.schema.xml PDS.schema.xml tde.schema.xml CTB.schema.xml 
-  NAMESPACE dunedaq::appmodel DEP_PKGS confmodel)
-
-daq_add_library(ConfigObjectFactory.cpp SmartDaqApplication.cpp ReadoutApplication.cpp NP02ReadoutApplication.cpp
-        DFApplication.cpp DFOApplication.cpp TPWriterApplication.cpp FakeDataApplication.cpp FakeHSIApplication.cpp 
-        DTSHSIApplication.cpp TriggerApplication.cpp MLTApplication.cpp HSIEventToTCApplication.cpp WIECApplication.cpp 
-        DaphneApplication.cpp SocketSenderApplication.cpp TDECrateApplication.cpp CTBApplication.cpp
-        LINK_LIBRARIES conffwk::conffwk fmt::fmt
-        logging::logging confmodel::confmodel oks::oks ers::ers)
+daq_add_dal_library(application.schema.xml hermes.schema.xml fdmodules.schema.xml trigger.schema.xml wiec.schema.xml PDS.schema.xml tde.schema.xml CTB.schema.xml
+  NAMESPACE dunedaq::appmodel DEP_PKGS confmodel
+    SOURCES ConfigObjectFactory.cpp ReadoutApplication.cpp SmartDaqApplication.cpp NP02ReadoutApplication.cpp
+        DFApplication.cpp DFOApplication.cpp TPWriterApplication.cpp FakeDataApplication.cpp FakeHSIApplication.cpp DTSHSIApplication.cpp TriggerApplication.cpp MLTApplication.cpp HSIEventToTCApplication.cpp WIECApplication.cpp DaphneApplication.cpp SocketSenderApplication.cpp TDECrateApplication.cpp CTBApplication.cpp
+   LINK_LIBRARIES conffwk::conffwk fmt::fmt logging::logging oks::oks ers::ers )
 
 daq_add_application(getAppsArguments get_apps_arguments.cxx
-  LINK_LIBRARIES confmodel::confmodel appmodel conffwk::conffwk)
+  LINK_LIBRARIES confmodel::confmodel appmodel_dal conffwk::conffwk)
 
-daq_add_python_bindings(*.cpp LINK_LIBRARIES appmodel confmodel::confmodel)
+daq_add_python_bindings(*.cpp LINK_LIBRARIES appmodel_dal confmodel::confmodel)
 
 daq_add_application(generate_modules_test generate_modules_test.cxx
- TEST LINK_LIBRARIES appmodel confmodel::confmodel conffwk::conffwk
+ TEST LINK_LIBRARIES appmodel_dal confmodel::confmodel conffwk::conffwk
  logging::logging)
 
 daq_add_application(print_detailed_config_info print_detailed_config_info.cxx
- TEST LINK_LIBRARIES appmodel confmodel::confmodel conffwk::conffwk
+ TEST LINK_LIBRARIES appmodel_dal confmodel::confmodel conffwk::conffwk
  logging::logging)
 
 daq_install()

--- a/cmake/appmodelConfig.cmake.in
+++ b/cmake/appmodelConfig.cmake.in
@@ -18,7 +18,11 @@ find_dependency(fmt)
 if (EXISTS ${CMAKE_SOURCE_DIR}/@PROJECT_NAME@)
 
 message(STATUS "Project \"@PROJECT_NAME@\" will be treated as repo (found in ${CMAKE_SOURCE_DIR}/@PROJECT_NAME@)")
-add_library(@PROJECT_NAME@::@PROJECT_NAME@ ALIAS @PROJECT_NAME@)
+
+add_library(@PROJECT_NAME@::@PROJECT_NAME@_dal ALIAS @PROJECT_NAME@_dal)
+
+add_library(@PROJECT_NAME@::dal            ALIAS @PROJECT_NAME@_dal)
+add_library(@PROJECT_NAME@::@PROJECT_NAME@ ALIAS @PROJECT_NAME@_dal)
 
 get_filename_component(@PROJECT_NAME@_DAQSHARE "${CMAKE_CURRENT_LIST_FILE}" DIRECTORY)
 
@@ -27,6 +31,9 @@ else()
 message(STATUS "Project \"@PROJECT_NAME@\" will be treated as installed package (found in ${CMAKE_CURRENT_LIST_DIR})")
 set_and_check(targets_file ${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake)
 include(${targets_file})
+
+add_library(@PROJECT_NAME@::dal            ALIAS @PROJECT_NAME@::@PROJECT_NAME@_dal)
+add_library(@PROJECT_NAME@::@PROJECT_NAME@ ALIAS @PROJECT_NAME@::@PROJECT_NAME@_dal)
 
 set(@PROJECT_NAME@_DAQSHARE "${CMAKE_CURRENT_LIST_DIR}/../../../share")
 


### PR DESCRIPTION
… against daq-cmake v3.1.0

The following PR enables this package to build on its patch branch against `daq-cmake` `v3.1.0`, which contains changes described in DUNE-DAQ/daq-cmake#155. 

This is only to be merged by Software Coordination. 