### PR TITLE
PDS/TPC RawDataProcessor added to the appmodel trigger schema

### DIFF
--- a/schema/appmodel/trigger.schema.xml
+++ b/schema/appmodel/trigger.schema.xml
@@ -177,7 +177,6 @@
 
  <class name="PDSRawDataProcessor" description="A class which contains info about PDS. For example here you can add threshold for specific channels.">
   <superclass name="RawDataProcessor"/>
-  <attribute name="rawdataprocessor_id" type="u32" init-value="234" is-not-null="yes"/>
   <attribute name="default_adc_intg_thresh" type="u32" init-value="0" is-not-null="yes"/>
  </class>
 

--- a/schema/appmodel/trigger.schema.xml
+++ b/schema/appmodel/trigger.schema.xml
@@ -175,6 +175,14 @@
   <relationship name="configuration" class-type="MLTConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
  </class>
 
+ <class name="PDSRawDataProcessor" description="A class which contains info about PDS. For example here you can add threshold for specific channels.">
+  <superclass name="RawDataProcessor"/>
+  <attribute name="rawdataprocessor_id" type="u32" init-value="234" is-not-null="yes"/>
+  <attribute name="default_adc_intg_thresh" type="u32" init-value="0" is-not-null="yes"/>
+  <relationship name="processing_steps" class-type="ProcessingStep" low-cc="zero" high-cc="many" is-composite="no" is-exclusive="no" is-dependent="no"/>
+  <relationship name="sot_minima" description="TP samples over threshold minimum requirement by plane." class-type="SamplesOverThresholdMinima" low-cc="zero" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
+ </class>
+
  <class name="ProcessingStep" description="Base class for TPG processors.">
   <superclass name="Jsonable"/>
  </class>
@@ -192,6 +200,12 @@
   <attribute name="trigger_rate_hz" description="Trigger rate (in Hz) for the RandomTCMaker to produce the TCs" type="float" init-value="1" is-not-null="yes"/>
   <attribute name="time_distribution" description="Type of distribution used for random timestamps (uniform or poisson)" type="enum" range="kUniform,kPoisson" init-value="kUniform" is-not-null="yes"/>
   <relationship name="tc_readout" description="Configuration for the TC output type and the TC window size" class-type="TCReadoutMap" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
+ </class>
+
+ <class name="TPCRawDataProcessor">
+  <superclass name="RawDataProcessor"/>
+  <relationship name="processing_steps" class-type="ProcessingStep" low-cc="one" high-cc="many" is-composite="no" is-exclusive="no" is-dependent="no"/>
+  <relationship name="sot_minima" description="TP samples over threshold minimum requirement by plane." class-type="SamplesOverThresholdMinima" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
  </class>
 
  <class name="RandomTCMakerModule">

--- a/schema/appmodel/trigger.schema.xml
+++ b/schema/appmodel/trigger.schema.xml
@@ -179,8 +179,6 @@
   <superclass name="RawDataProcessor"/>
   <attribute name="rawdataprocessor_id" type="u32" init-value="234" is-not-null="yes"/>
   <attribute name="default_adc_intg_thresh" type="u32" init-value="0" is-not-null="yes"/>
-  <relationship name="processing_steps" class-type="ProcessingStep" low-cc="zero" high-cc="many" is-composite="no" is-exclusive="no" is-dependent="no"/>
-  <relationship name="sot_minima" description="TP samples over threshold minimum requirement by plane." class-type="SamplesOverThresholdMinima" low-cc="zero" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
  </class>
 
  <class name="ProcessingStep" description="Base class for TPG processors.">
@@ -217,8 +215,6 @@
   <superclass name="DataProcessor"/>
   <attribute name="channel_mask" description="List of channels to be masked from TP generation" type="u32" is-multi-value="yes"/>
   <attribute name="channel_map" type="string"/>
-  <relationship name="processing_steps" class-type="ProcessingStep" low-cc="one" high-cc="many" is-composite="no" is-exclusive="no" is-dependent="no"/>
-  <relationship name="sot_minima" description="TP samples over threshold minimum requirement by plane." class-type="SamplesOverThresholdMinima" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
  </class>
 
  <class name="StandaloneTCMakerConf" is-abstract="yes">


### PR DESCRIPTION
RawDataProcessor changed into TPCRawDataProcessosr and PDSRawDataProcessor. 
This is a simple way to have configurable thresholds and masked channels for the PDSRawDataProcessor in a similar way as th WIBs. 

Code passed all integration tests when run only with patch/fddaq-v5.3.x for the other repos.  