### PR TITLE
Adding throw to base generate_modules

### DIFF
--- a/include/appmodel/appmodelIssues.hpp
+++ b/include/appmodel/appmodelIssues.hpp
@@ -20,7 +20,11 @@ namespace dunedaq {
         MissingDaphne,
         "Daphne " << id << " has active channels but its turned off",
         ((size_t)id))
-
+  
+  ERS_DECLARE_ISSUE(appmodel,
+        UnimplementedMethodCalled,
+        "Method '" << method_name << "' was called but is not implemented in this class",
+        ((std::string)method_name))
 
 }
 

--- a/src/SmartDaqApplication.cpp
+++ b/src/SmartDaqApplication.cpp
@@ -8,7 +8,8 @@ namespace appmodel {
 
 std::vector<const dunedaq::confmodel::DaqModule*>
 SmartDaqApplication::generate_modules(const confmodel::Session* session) const {
-    // TODO : add warining/assert/exception
+    (void)session;
+    throw appmodel::UnimplementedMethodCalled(ERS_HERE, "SmartDaqApplication::generate_modules");
 }
 
 const std::vector<std::string> SmartDaqApplication::construct_commandline_parameters(

--- a/src/SmartDaqApplication.cpp
+++ b/src/SmartDaqApplication.cpp
@@ -7,8 +7,7 @@ namespace dunedaq {
 namespace appmodel {
 
 std::vector<const dunedaq::confmodel::DaqModule*>
-SmartDaqApplication::generate_modules(const confmodel::Session* session) const {
-    (void)session;
+SmartDaqApplication::generate_modules(const confmodel::Session* /* session */ ) const {
     throw appmodel::UnimplementedMethodCalled(ERS_HERE, "SmartDaqApplication::generate_modules");
 }
 


### PR DESCRIPTION
specifically to get rid of this compiler warning:

```
[186/248] Building CXX object appmodel/CMakeFiles/appmodel_dal.dir/src/SmartDaqApplication.cpp.o
/nfs/home/mrigan/dune-daq/fddaq-v5.3.2-rc3-a9/sourcecode/appmodel/src/SmartDaqApplication.cpp: In member function 'virtual std::vector<const dunedaq::confmodel::DaqModule*> dunedaq::appmodel::SmartDaqApplication::generate_modules(const dunedaq::confmodel::Session*) const':
/nfs/home/mrigan/dune-daq/fddaq-v5.3.2-rc3-a9/sourcecode/appmodel/src/SmartDaqApplication.cpp:12:1: warning: no return statement in function returning non-void [-Wreturn-type]
   12 | }
      | ^
/nfs/home/mrigan/dune-daq/fddaq-v5.3.2-rc3-a9/sourcecode/appmodel/src/SmartDaqApplication.cpp:10:65: warning: unused parameter 'session' [-Wunused-parameter]
   10 | SmartDaqApplication::generate_modules(const confmodel::Session* session) const {
      |                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
```

I wondered whether it was supposed to be purely virtual class (and therefore we could just fix by setting it appropriately =0) but there was a note `// TODO : add warining/assert/exception` so I assumed the exception was more appropriate.
