### PR TITLE
Add capacity parameter to NetworkConnectionDescription.

### DIFF
--- a/schema/appmodel/application.schema.xml
+++ b/schema/appmodel/application.schema.xml
@@ -362,7 +362,7 @@
  <class name="NetworkConnectionDescriptor">
   <attribute name="uid_base" description="Base for UID string. To be combined with a source id" type="string" is-not-null="yes"/>
   <attribute name="connection_type" type="enum" range="kSendRecv,kPubSub" init-value="kSendRecv" is-not-null="yes"/>
-  <attribute name="capacity" type="u32" init-value="1000" is-not-null="yes"/>
+  <attribute name="capacity" type="u32" init-value="0"/>
   <attribute name="data_type" description="string identifying type of data transferred through this connection" type="string" is-not-null="yes"/>
   <relationship name="associated_service" description="Service provided by this connection" class-type="Service" low-cc="one" high-cc="one" is-composite="yes" is-exclusive="no" is-dependent="yes"/>
  </class>

--- a/schema/appmodel/application.schema.xml
+++ b/schema/appmodel/application.schema.xml
@@ -345,6 +345,7 @@
  <class name="NetworkConnectionDescriptor">
   <attribute name="uid_base" description="Base for UID string. To be combined with a source id" type="string" is-not-null="yes"/>
   <attribute name="connection_type" type="enum" range="kSendRecv,kPubSub" init-value="kSendRecv" is-not-null="yes"/>
+  <attribute name="capacity" type="u32" init-value="1000" is-not-null="yes"/>
   <attribute name="data_type" description="string identifying type of data transferred through this connection" type="string" is-not-null="yes"/>
   <relationship name="associated_service" description="Service provided by this connection" class-type="Service" low-cc="one" high-cc="one" is-composite="yes" is-exclusive="no" is-dependent="yes"/>
  </class>

--- a/src/ReadoutApplication.cpp
+++ b/src/ReadoutApplication.cpp
@@ -419,6 +419,9 @@ ReadoutApplication::generate_modules(const confmodel::Session* session) const
         auto frag_conn = obj_fac.create("NetworkConnection", dreqNetUid);
 
         frag_conn.set_by_val<std::string>("data_type", descriptor->get_data_type());
+
+        // Override capacity, set to 2x expected number of Fragments
+        frag_conn.set_by_val<int>("capacity", all_enabled_det_streams.size() * 2);
         frag_conn.set_by_val<std::string>("connection_type", descriptor->get_connection_type());
 
         auto serviceObj = descriptor->get_associated_service()->config_object();


### PR DESCRIPTION
Set capacity of Fragment output connection to twice the number of streams (i.e. enough for just 2 TriggerRecords) in ReadoutApplication.

This capacity is then passed to `ipm`, see https://github.com/DUNE-DAQ/ipm/pull/109