### PR TITLE
Added the timesync input connection to the Fake HSI object in the FakeHSIApplication

### DIFF
--- a/src/FakeHSIApplication.cpp
+++ b/src/FakeHSIApplication.cpp
@@ -159,6 +159,10 @@ FakeHSIApplication::generate_modules(const confmodel::Session* session) const
     obj_fac.create("FakeHSIEventGeneratorModule", genuid);
   fakehsiObj.set_obj("configuration", &rdrConf->config_object());
   fakehsiObj.set_objs("outputs", { &queueObj, &hsiNetObj });
+  if (tsNetDesc != nullptr) {
+    conffwk::ConfigObject tsNetObjIn = obj_fac.create_net_obj(tsNetDesc, ".*");
+    fakehsiObj.set_objs("inputs", { &tsNetObjIn });
+  }
 
   modules.push_back(obj_fac.get_dal<FakeHSIEventGeneratorModule>(genuid));
 


### PR DESCRIPTION
…, so that it will correctly appear in our configuration diagrams and other diagnostic tools.

We've noticed that the TimeSync "connection" into the FakeHSI application is missing in our configuration diagrams.  The change in this PR fixes that.  I'll add before/after diagrams to this PR.

To see the results of these changes, we can run 

- `generate_modules_test local-1x1-config hsi-fake-01 config/daqsystemtest/example-configs.data.xml`
    - and look at the "input objects"

or run

- `create_config_plot -f config/daqsystemtest/example-configs.data.xml -s local-1x1-config`, etc

This PR will have a follow-up one in `hsilibs`, in which we make use of the TimeSync connection that is providing in the confguration...

![07Jul_local-1x1-config_system](https://github.com/user-attachments/assets/1a5c964a-ee70-46eb-96d5-bf7c3002e24a)
![07Jul_local-1x1-config_system](https://github.com/user-attachments/assets/c73cb2de-a0c0-41fa-96e7-9fd86360ccc8)
