### PR TITLE
Postprocessing delay min and max wait conf params

### DIFF
--- a/schema/appmodel/application.schema.xml
+++ b/schema/appmodel/application.schema.xml
@@ -80,7 +80,7 @@
 
 <oks-schema>
 
-<info name="" type="" num-of-items="56" oks-format="schema" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20230616T091343" last-modified-by="gjc" last-modified-on="latitude" last-modification-time="20250626T122830"/>
+<info name="" type="" num-of-items="56" oks-format="schema" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20230616T091343" last-modified-by="dergonul" last-modified-on="np04-srv-028.cern.ch" last-modification-time="20250729T142105"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
@@ -153,6 +153,8 @@
   <attribute name="input_data_type" description="Type of data received by this readout module" type="string" init-value="WIBEthFrame"/>
   <attribute name="generate_timesync" type="bool" init-value="true" is-not-null="yes"/>
   <attribute name="post_processing_delay_ticks" description="Number of clock tick by which post processing of incoming data shall be delayed." type="u64" init-value="0" is-not-null="yes"/>
+  <attribute name="post_processing_delay_min_wait" description="Minimum time (ms) between consecutive post processing operations." type="u64" init-value="1" is-not-null="yes"/>
+  <attribute name="post_processing_delay_max_wait" description="Maximum wait time (ms) before post processing check if no new data arrives." type="u64" init-value="5" is-not-null="yes"/>
   <relationship name="request_handler" class-type="RequestHandler" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <relationship name="latency_buffer" class-type="LatencyBuffer" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <relationship name="data_processor" class-type="DataProcessor" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>


### PR DESCRIPTION
- If data arrives less than `post_processing_delay_min_wait` milliseconds since the last time postprocessing eligibility check was done, postprocessing will be delayed. [This value was previously hardcoded as 1.](https://github.com/DUNE-DAQ/datahandlinglibs/blob/84bd8fc8ec8330c3cb1056dcbbcc63cc196051e5/include/datahandlinglibs/models/detail/DataHandlingModel.hxx#L279)

- If no data arrives in `post_processing_delay_max_wait` milliseconds, postprocessing eligibility check will still take place. This is a new feature of delayed postprocessing to cover the case when there is data in the buffer that is eligible for postprocessing but no new data arrives to trigger the check.

I would appreciate your input on the `init-value`s.

Related: [Delayed postprocessing rework #66](https://github.com/DUNE-DAQ/datahandlinglibs/pull/66)