### PR TITLE
Make FDFakeReaderModule work with CRT frames

### DIFF
--- a/schema/appmodel/fdmodules.schema.xml
+++ b/schema/appmodel/fdmodules.schema.xml
@@ -80,7 +80,7 @@
 
 <oks-schema>
 
-<info name="" type="" num-of-items="23" oks-format="schema" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20230616T091343" last-modified-by="gjc" last-modified-on="latitude" last-modification-time="20250623T154337"/>
+<info name="" type="" num-of-items="29" oks-format="schema" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20230616T091343" last-modified-by="dergonul" last-modified-on="np04-srv-028.cern.ch" last-modification-time="20250808T131007"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
@@ -102,6 +102,10 @@
 
  <class name="CRTGrenobleReaderModule">
   <superclass name="DataReaderModule"/>
+ </class>
+
+ <class name="CRTReaderConf">
+  <superclass name="DataReaderConf"/>
  </class>
 
  <class name="DPDKPortConfiguration">

--- a/src/CRTReaderApplication.cpp
+++ b/src/CRTReaderApplication.cpp
@@ -145,6 +145,7 @@ CRTReaderApplication::generate_modules(const confmodel::Session* session) const
 
     // Populate configuration and interfaces (leave output queues for later)
     reader_obj.set_obj("configuration", &reader_conf->config_object());
+    reader_obj.set_objs("connections", {&d2d_conn->config_object()});
     reader_obj.set_objs("outputs", data_queue_objs);
 
     modules.push_back(obj_fac.get_dal<confmodel::DaqModule>(reader_obj.UID()));


### PR DESCRIPTION
- `CRTReaderConf` to have a common class for CRT frames:
```
<obj class="CRTReaderConf" id="def-emu-crt-receiver-conf">
 <attr name="template_for" type="class" val="FDFakeReaderModule"/>
 <attr name="emulation_mode" type="bool" val="1"/>
 <rel name="emulation_conf" class="StreamEmulationParameters" id="stream-emu"/>
</obj>
```
- Added `connections` since it was required when using `FDFakeReaderModule`

The following is the list of relevant branches (where `SkipListLatencyBufferModel` is used as the buffer type):
asiolibs: dte/asio_integtest
daqsystemtest: dte/emu_crt
appmodel: dte/fakereader_crt
fdreadoutlibs: dte/queue_for_crt
fdreadoutmodules: dte/queue_for_crt
crtmodules: dte/crt_integtest