### PR TITLE
Processor metric collection related configuration

### DIFF
--- a/schema/appmodel/trigger.schema.xml
+++ b/schema/appmodel/trigger.schema.xml
@@ -198,7 +198,6 @@
   <superclass name="RawDataProcessor"/>
   <relationship name="processing_steps" class-type="ProcessingStep" low-cc="one" high-cc="many" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <relationship name="sot_minima" description="TP samples over threshold minimum requirement by plane." class-type="SamplesOverThresholdMinima" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
-  <attribute name="metric_collect_enable" description="Whether to enable processor metric collection" type="bool" init-value="0"/>
   <attribute name="metric_collect_opmon_rate" description="The rate at which processor metric is polled from processors for monitoring" type="u32" init-value="1"/>
  </class>
 

--- a/schema/appmodel/trigger.schema.xml
+++ b/schema/appmodel/trigger.schema.xml
@@ -100,7 +100,7 @@
  <class name="AVXFrugalPedestalSubtractProcessor" description="TPG frugal pedestal subtraction signal processor. Frugally updates the pedestal estimation and outputs the difference with the input signal.">
   <superclass name="ProcessingStep"/>
   <attribute name="accum_limit" description="Accumulation limit to increment/decrement the estimated pedestal value." type="u8" init-value="10" is-not-null="yes"/>
-  <attribute name="metric_collect_data_sample_rate" description="Rate in terms of time samples to store metric values in processors." type="u8" init-value="128" is-not-null="no"/>
+  <attribute name="metric_collect_data_sample_rate" description="Rate in terms of time samples to store metric values in processors." type="u64" init-value="128" is-not-null="no"/>
   <attribute name="metric_collect_toggle_state" description="Whether metric storaging function is enabled." type="bool" init-value="0" is-not-null="no"/>
  </class>
 

--- a/schema/appmodel/trigger.schema.xml
+++ b/schema/appmodel/trigger.schema.xml
@@ -100,6 +100,8 @@
  <class name="AVXFrugalPedestalSubtractProcessor" description="TPG frugal pedestal subtraction signal processor. Frugally updates the pedestal estimation and outputs the difference with the input signal.">
   <superclass name="ProcessingStep"/>
   <attribute name="accum_limit" description="Accumulation limit to increment/decrement the estimated pedestal value." type="u8" init-value="10" is-not-null="yes"/>
+  <attribute name="metric_collect_data_sample_rate" description="Rate in terms of time samples to store metric values in processors." type="u8" init-value="128" is-not-null="no"/>
+  <attribute name="metric_collect_toggle_state" description="Whether metric storaging function is enabled." type="bool" init-value="0" is-not-null="no"/>
  </class>
 
  <class name="AVXRunSumProcessor" description="TPG running sum signal processor. Outputs a scaled running sum from the input signal.">
@@ -196,6 +198,8 @@
   <superclass name="RawDataProcessor"/>
   <relationship name="processing_steps" class-type="ProcessingStep" low-cc="one" high-cc="many" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <relationship name="sot_minima" description="TP samples over threshold minimum requirement by plane." class-type="SamplesOverThresholdMinima" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
+  <attribute name="metric_collect_enable" description="Whether to enable processor metric collection" type="bool" init-value="0"/>
+  <attribute name="metric_collect_opmon_rate" description="The rate at which processor metric is polled from processors for monitoring" type="u32" init-value="1"/>
  </class>
 
  <class name="RandomTCMakerModule">

--- a/schema/appmodel/trigger.schema.xml
+++ b/schema/appmodel/trigger.schema.xml
@@ -100,8 +100,6 @@
  <class name="AVXFrugalPedestalSubtractProcessor" description="TPG frugal pedestal subtraction signal processor. Frugally updates the pedestal estimation and outputs the difference with the input signal.">
   <superclass name="ProcessingStep"/>
   <attribute name="accum_limit" description="Accumulation limit to increment/decrement the estimated pedestal value." type="u8" init-value="10" is-not-null="yes"/>
-  <attribute name="metric_collect_data_sample_rate" description="Rate in terms of time samples to store metric values in processors." type="u64" init-value="128" is-not-null="no"/>
-  <attribute name="metric_collect_toggle_state" description="Whether metric storaging function is enabled." type="bool" init-value="0" is-not-null="no"/>
  </class>
 
  <class name="AVXRunSumProcessor" description="TPG running sum signal processor. Outputs a scaled running sum from the input signal.">
@@ -177,6 +175,8 @@
 
  <class name="ProcessingStep" description="Base class for TPG processors.">
   <superclass name="Jsonable"/>
+  <attribute name="metric_collect_time_sample_period" description="If metric_collect_toggle_state is true, the processor will store values of its monitored quantities every metric_collect_time_sample_period time samples." type="u64" init-value="256" is-not-null="no"/>
+  <attribute name="metric_collect_toggle_state" description="Whether metric storaging function is enabled." type="bool" init-value="0" is-not-null="no"/>
  </class>
 
  <class name="ROIGroupConf">


### PR DESCRIPTION
### Summary of changes

This PR adds four new attribute definitions under classes `AVXFrugalPedestalSubtractProcessor` and `TPCRawDataProcessor`. 

These attributes are added to control behaviour of classes introduced in the following PR.

https://github.com/DUNE-DAQ/tpglibs/pull/27
https://github.com/DUNE-DAQ/fdreadoutlibs/pull/272
https://github.com/DUNE-DAQ/datahandlinglibs/pull/70

### New configuration items

#### In `AVXFrugalPedestalSubtractProcessor`
- `metric_collect_data_sample_rate` defaults to 128, it is the rate at which metric data is stored to the dedicated metric buffer, waiting to be polled. The rate is defined in terms of time samples (or how many times `process` method is ran).
- `metric_collect_toggle_state` is a bool that controls whether the metric saving function is ran periodically at all (rate defined above). The default value is false (off).

#### In `TPCRawDataProcessor`
- `metric_collect_enable` is a bool toggle that controls whether upstream `ProcessorMetricCollector` object is created and called to collect metrics. The default is false (off). 
- `metric_collect_opmon_rate` controls the rate in terms of data frames (in terms of frame counter), for which the `ProcessorMetricCollector` updates its internal record of metric from polling from all processors registered on it. 

### Usage Note

It should be noted that it only makes sense to have `metric_collect_toggle_state` and `metric_collect_enable` in the two classes set to the same value (both true or both false), as it corresponds to the producer and collector, respectively.

