### PR TITLE
Modified FakeHSIApplication.cpp so that it complains, …

### DIFF
--- a/src/FakeHSIApplication.cpp
+++ b/src/FakeHSIApplication.cpp
@@ -50,6 +50,13 @@ FakeHSIApplication::generate_modules(const confmodel::Session* session) const
   auto dlhConf = get_link_handler();
   auto dlhClass = dlhConf->get_template_for();
 
+  // 23-Sep-2025, KAB et al: prevent a mis-configuration of the system in which the
+  // FakeHSI DLH is told to generate TimeSync messages. (TimeSync messages should only
+  // be sent from Readout DLH modules so that we don't get confusing system behavior.)
+  if (dlhConf->get_generate_timesync()) {
+    throw(BadConf(ERS_HERE, "TimeSync generation is enabled for a FakeHSIApplication and this is not allowed"));
+  }
+
   const QueueDescriptor* dlhInputQDesc = nullptr;
 
   for (auto rule : get_queue_rules()) {


### PR DESCRIPTION
…and prevents the FakeHSIApp from successfully running, if the configuration requests that TimeSync messages get sent from the FakeHSI DLH.

## Description

This Pull Request is part of the changes described in DUNE-DAQ/daq-deliverables#188.  Those changes remove the process ID checking that was previously done in the `TimestampEstimatorTimeSync` class to prevent a FakeHSI DataLinkHandler from sending TimeSync messages to the FakeHSIEventGenerator.

Instead of having that sanity check in `TimestampEstimatorTimeSync` (which relied on the use of Linux PIDs), we are choosing to prevent such a mis-configuration of the system by checking for a valid setting of the `generate_timesync` attribute in the FakeHSI DLH configuration.  This validation check is done in the `appmodel/FakeHSIApplication` class, and it throws an exception if the validation fails.  This exception causes the FakeHSI app to fail to start, and an error message is written to the log file to describe the invalid configuration setting.

This change can be tested and merged independently of the other ones that are part of DUNE-DAQ/daq-deliverables#188.

## Testing Suggestions

Here are suggested steps for validating this change.  They locally mis-configure the system, run a regression test that does not include this change, and then run a regression test that does include this change.

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest
dbt-create -n NFD_DEV_250923_A9 ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b develop
git clone https://github.com/DUNE-DAQ/appmodel -b develop
cd ..

sed -i 's,<attr name="generate_timesync" type="bool" val="0"/>,<attr name="generate_timesync" type="bool" val="1"/>,' sourcecode/daqsystemtest/config/daqsystemtest/integrationtest-objects.data.xml

dbt-workarea-env
dbt-build -j 12
dbt-workarea-env

daqsystemtest_integtest_bundle.sh -k small
echo " *** Note that the previous regression test did not fail."

cd sourcecode/appmodel
git checkout kbiery/time_sync_source_id
cd ../../
dbt-build -j 12
dbt-workarea-env

daqsystemtest_integtest_bundle.sh -k small
echo " *** Note that the previous regression test *did* fail, as it should."
```