### PR TITLE
TPG internal state monitoring

### DIFF
--- a/schema/appmodel/trigger.schema.xml
+++ b/schema/appmodel/trigger.schema.xml
@@ -175,8 +175,9 @@
 
  <class name="ProcessingStep" description="Base class for TPG processors.">
   <superclass name="Jsonable"/>
-  <attribute name="metric_collect_time_sample_period" description="If metric_collect_toggle_state is true, the processor will store values of its monitored quantities every metric_collect_time_sample_period time samples." type="u64" init-value="256" is-not-null="no"/>
+  <attribute name="metric_collect_time_sample_period" description="If metric_collect_toggle_state is true, the processor will store values of its monitored quantities every metric_collect_time_sample_period time samples." type="u64" init-value="32768" is-not-null="no"/>
   <attribute name="metric_collect_toggle_state" description="Whether metric storaging function is enabled." type="bool" init-value="0" is-not-null="no"/>
+  <attribute name="requested_internal_states" description="config string for internal states to be collected" type="string" init-value="" is-not-null="no"/>
  </class>
 
  <class name="ROIGroupConf">
@@ -390,7 +391,7 @@
   <superclass name="RawDataProcessor"/>
   <attribute name="frame_count_limit" description="When this number of frames is reached the TPs are sent to the sink. SELECT 0 if you want this condition not to be used. In this case, sending TPs will only rely on the number of TP." type="u32" init-value="100" is-not-null="yes"/>
   <attribute name="tp_count_limit" description="When this number of TPs is reached, the TPs are sent to the sink. SELECT 0 if you want this condition not to be used. In this case, sending TPs will only rely on the number of frames." type="u32" init-value="0" is-not-null="yes"/>
-  <attribute name="metric_collect_opmon_rate" description="The rate at which processor metric is polled from processors for monitoring" type="u32" init-value="1"/>
+  <attribute name="metric_collect_opmon_period" description="The rate at which processor metric is polled from processors for monitoring" type="u32" init-value="32768"/>
   <relationship name="processing_steps" class-type="ProcessingStep" low-cc="one" high-cc="many" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <relationship name="sot_minima" description="TP samples over threshold minimum requirement by plane." class-type="SamplesOverThresholdMinima" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
  </class>

--- a/schema/appmodel/trigger.schema.xml
+++ b/schema/appmodel/trigger.schema.xml
@@ -175,7 +175,7 @@
 
  <class name="ProcessingStep" description="Base class for TPG processors.">
   <superclass name="Jsonable"/>
-  <attribute name="metric_collect_time_sample_period" description="If metric_collect_toggle_state is true, the processor will store values of its monitored quantities every metric_collect_time_sample_period time samples." type="u64" init-value="32768" is-not-null="no"/>
+  <attribute name="metric_collect_time_sample_period" description="If metric_collect_toggle_state is true, the processor will store values of its monitored quantities every metric_collect_time_sample_period time samples." type="u64" init-value="100000" is-not-null="no"/>
   <attribute name="metric_collect_toggle_state" description="Whether metric storaging function is enabled." type="bool" init-value="0" is-not-null="no"/>
   <attribute name="requested_internal_states" description="config string for internal states to be collected" type="string" init-value="" is-not-null="no"/>
  </class>
@@ -391,7 +391,7 @@
   <superclass name="RawDataProcessor"/>
   <attribute name="frame_count_limit" description="When this number of frames is reached the TPs are sent to the sink. SELECT 0 if you want this condition not to be used. In this case, sending TPs will only rely on the number of TP." type="u32" init-value="100" is-not-null="yes"/>
   <attribute name="tp_count_limit" description="When this number of TPs is reached, the TPs are sent to the sink. SELECT 0 if you want this condition not to be used. In this case, sending TPs will only rely on the number of frames." type="u32" init-value="0" is-not-null="yes"/>
-  <attribute name="metric_collect_opmon_period" description="The rate at which processor metric is polled from processors for monitoring" type="u32" init-value="32768"/>
+  <attribute name="metric_collect_opmon_period" description="The rate at which processor metric is polled from processors for monitoring" type="u32" init-value="100000"/>
   <relationship name="processing_steps" class-type="ProcessingStep" low-cc="one" high-cc="many" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <relationship name="sot_minima" description="TP samples over threshold minimum requirement by plane." class-type="SamplesOverThresholdMinima" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
  </class>


### PR DESCRIPTION
Configuration attributes change are jointly developed with the tpglibs processor internal state API development at https://github.com/DUNE-DAQ/tpglibs/pull/33.

Added new "requested_internal_states" for processing steps.

Renamed "metric_collect_opmon_rate" to "metric_collect_opmon_period" for consistency.