### PR TITLE
Add Configurable RunSum Divisors.

### DIFF
--- a/schema/appmodel/trigger.schema.xml
+++ b/schema/appmodel/trigger.schema.xml
@@ -104,12 +104,18 @@
 
  <class name="AVXRunSumProcessor" description="TPG running sum signal processor. Outputs a scaled running sum from the input signal.">
   <superclass name="ProcessingStep"/>
-  <attribute name="memory_factor_plane0" description="Running sum memory factor for plane 0. Gets divided by 10." type="u8" range="0..10" init-value="8" is-not-null="yes"/>
-  <attribute name="memory_factor_plane1" description="Running sum memory factor for plane 1. Gets divided by 10." type="u8" range="0..10" init-value="8" is-not-null="yes"/>
-  <attribute name="memory_factor_plane2" description="Running sum memory factor for plane 2. Gets divided by 10." type="u8" range="0..10" init-value="8" is-not-null="yes"/>
-  <attribute name="scale_factor_plane0" description="Running sum scale factor for plane 0. Gets divided by 10." type="u8" range="1..10" init-value="10" is-not-null="yes"/>
-  <attribute name="scale_factor_plane1" description="Running sum scale factor for plane 1. Gets divided by 10." type="u8" range="1..10" init-value="10" is-not-null="yes"/>
-  <attribute name="scale_factor_plane2" description="Running sum scale factor for plane 2. Gets divided by 10." type="u8" range="1..10" init-value="10" is-not-null="yes"/>
+  <attribute name="memory_factor_plane0" description="Running sum memory factor for plane 0." type="u8" init-value="4" is-not-null="yes"/>
+  <attribute name="memory_factor_plane1" description="Running sum memory factor for plane 1." type="u8" init-value="4" is-not-null="yes"/>
+  <attribute name="memory_factor_plane2" description="Running sum memory factor for plane 2." type="u8" init-value="4" is-not-null="yes"/>
+  <attribute name="memory_divisor_plane0" description="Running sum memory divisor for plane 0." type="u8" init-value="5" is-not-null="yes"/>
+  <attribute name="memory_divisor_plane1" description="Running sum memory divisor for plane 1." type="u8" init-value="5" is-not-null="yes"/>
+  <attribute name="memory_divisor_plane2" description="Running sum memory divisor for plane 2." type="u8" init-value="5" is-not-null="yes"/>
+  <attribute name="scale_factor_plane0" description="Running sum scale factor for plane 0." type="u8" init-value="1" is-not-null="yes"/>
+  <attribute name="scale_factor_plane1" description="Running sum scale factor for plane 1." type="u8" init-value="1" is-not-null="yes"/>
+  <attribute name="scale_factor_plane2" description="Running sum scale factor for plane 2." type="u8" init-value="1" is-not-null="yes"/>
+  <attribute name="scale_divisor_plane0" description="Running sum scale divisor for plane 0." type="u8" init-value="1" is-not-null="yes"/>
+  <attribute name="scale_divisor_plane1" description="Running sum scale divisor for plane 1." type="u8" init-value="1" is-not-null="yes"/>
+  <attribute name="scale_divisor_plane2" description="Running sum scale divisor for plane 2." type="u8" init-value="1" is-not-null="yes"/>
  </class>
 
  <class name="AVXThresholdProcessor" description="TPG threshold signal processor. Filters the input signal by passing values that are above threshold and suppresing otherwise.">


### PR DESCRIPTION
# Description

This PR is related to https://github.com/DUNE-DAQ/tpglibs/pull/34 by making the new divisor parameters in `AVXRunSumProcessor` configurable.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

Testing that the configs went through was primarily done through integration tests and local runs by changing the config values and seeing the resultant change in TPs (or through debug outputs of the set values).

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

