### PR TITLE
Updated trigger candidate maker configuration schema

### DIFF
--- a/schema/appmodel/trigger.schema.xml
+++ b/schema/appmodel/trigger.schema.xml
@@ -200,7 +200,7 @@
   <attribute name="trigger_rate_hz" description="Trigger rate (in Hz) for the RandomTCMaker to produce the TCs" type="float" init-value="1" is-not-null="yes"/>
   <attribute name="time_distribution" description="Type of distribution used for random timestamps (uniform or poisson)" type="enum" range="kUniform,kPoisson" init-value="kUniform" is-not-null="yes"/>
   <attribute name="candidate_type_name" description="Enumerator name of the TC type, e.g. kTiming" type="string" init-value="kRandom" is-not-null="yes"/>
-  <attribute name="candidate_backshift_ts" type="s32" init-value="1000" is-not-null="yes"/>
+  <attribute name="candidate_backshift_ts" type="s64" init-value="1000" is-not-null="yes"/>
   <attribute name="candidate_window_before_ts" type="u32" init-value="1000" is-not-null="yes"/>
   <attribute name="candidate_window_after_ts" type="u32" init-value="1000" is-not-null="yes"/>
 </class>

--- a/schema/appmodel/trigger.schema.xml
+++ b/schema/appmodel/trigger.schema.xml
@@ -200,7 +200,7 @@
   <attribute name="trigger_rate_hz" description="Trigger rate (in Hz) for the RandomTCMaker to produce the TCs" type="float" init-value="1" is-not-null="yes"/>
   <attribute name="time_distribution" description="Type of distribution used for random timestamps (uniform or poisson)" type="enum" range="kUniform,kPoisson" init-value="kUniform" is-not-null="yes"/>
   <attribute name="candidate_type_name" description="Enumerator name of the TC type, e.g. kTiming" type="string" init-value="kRandom" is-not-null="yes"/>
-  <attribute name="candidate_offset_ts" type="s64" init-value="1000" is-not-null="yes"/>
+  <attribute name="candidate_offset_ts" type="s32" init-value="1000" is-not-null="yes"/>
   <attribute name="candidate_window_before_ts" type="u32" init-value="1000" is-not-null="yes"/>
   <attribute name="candidate_window_after_ts" type="u32" init-value="1000" is-not-null="yes"/>
 </class>

--- a/schema/appmodel/trigger.schema.xml
+++ b/schema/appmodel/trigger.schema.xml
@@ -200,9 +200,9 @@
   <attribute name="trigger_rate_hz" description="Trigger rate (in Hz) for the RandomTCMaker to produce the TCs" type="float" init-value="1" is-not-null="yes"/>
   <attribute name="time_distribution" description="Type of distribution used for random timestamps (uniform or poisson)" type="enum" range="kUniform,kPoisson" init-value="kUniform" is-not-null="yes"/>
   <attribute name="candidate_type_name" description="Enumerator name of the TC type, e.g. kTiming" type="string" init-value="kRandom" is-not-null="yes"/>
-  <attribute name="candidate_backshift_ts" type="s64" init-value="1000" is-not-null="yes"/>
-  <attribute name="candidate_window_before_ts" type="u32" init-value="1000" is-not-null="yes"/>
-  <attribute name="candidate_window_after_ts" type="u32" init-value="1000" is-not-null="yes"/>
+  <attribute name="candidate_backshift_ts" type="s64" description="Time backshift applied to the TC central time at the creation of the TC" init-value="1000" is-not-null="yes"/>
+  <attribute name="candidate_window_before_ts" type="u32" description="Candidate extension before its central time" init-value="1000" is-not-null="yes"/>
+  <attribute name="candidate_window_after_ts" type="u32" description="Candidate extension after its central time" init-value="1000" is-not-null="yes"/>
 </class>
 
  <class name="RandomTCMakerModule">

--- a/schema/appmodel/trigger.schema.xml
+++ b/schema/appmodel/trigger.schema.xml
@@ -200,7 +200,7 @@
   <attribute name="trigger_rate_hz" description="Trigger rate (in Hz) for the RandomTCMaker to produce the TCs" type="float" init-value="1" is-not-null="yes"/>
   <attribute name="time_distribution" description="Type of distribution used for random timestamps (uniform or poisson)" type="enum" range="kUniform,kPoisson" init-value="kUniform" is-not-null="yes"/>
   <attribute name="candidate_type_name" description="Enumerator name of the TC type, e.g. kTiming" type="string" init-value="kRandom" is-not-null="yes"/>
-  <attribute name="candidate_offset_ts" type="s32" init-value="1000" is-not-null="yes"/>
+  <attribute name="candidate_backshift_ts" type="s32" init-value="1000" is-not-null="yes"/>
   <attribute name="candidate_window_before_ts" type="u32" init-value="1000" is-not-null="yes"/>
   <attribute name="candidate_window_after_ts" type="u32" init-value="1000" is-not-null="yes"/>
 </class>

--- a/schema/appmodel/trigger.schema.xml
+++ b/schema/appmodel/trigger.schema.xml
@@ -199,8 +199,11 @@
   <attribute name="template_for" type="class" init-value="RandomTCMakerModule"/>
   <attribute name="trigger_rate_hz" description="Trigger rate (in Hz) for the RandomTCMaker to produce the TCs" type="float" init-value="1" is-not-null="yes"/>
   <attribute name="time_distribution" description="Type of distribution used for random timestamps (uniform or poisson)" type="enum" range="kUniform,kPoisson" init-value="kUniform" is-not-null="yes"/>
-  <relationship name="tc_readout" description="Configuration for the TC output type and the TC window size" class-type="TCReadoutMap" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
- </class>
+  <attribute name="candidate_type_name" description="Enumerator name of the TC type, e.g. kTiming" type="string" init-value="kRandom" is-not-null="yes"/>
+  <attribute name="candidate_offset_ts" type="s64" init-value="1000" is-not-null="yes"/>
+  <attribute name="candidate_window_before_ts" type="u32" init-value="1000" is-not-null="yes"/>
+  <attribute name="candidate_window_after_ts" type="u32" init-value="1000" is-not-null="yes"/>
+</class>
 
  <class name="RandomTCMakerModule">
   <superclass name="StandaloneTCMakerModule"/>


### PR DESCRIPTION
# Description

Updates the  configuration schema to support the new `RandomTriggerCandidate` configuration parameters.

Replaces the `tc_readout` `RandomTCMakerConf` field with explicit parameters:
- `candidate_type_name`
- `candidate_offset_ts`
- `candidate_window_before_ts`
- `candidate_window_after_ts`

Addresses issue [#415](https://github.com/DUNE-DAQ/trigger/issues/415)

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

