### PR TITLE
Fix CRTReaderApplication Queue Descriptor Retrieval

### DIFF
--- a/src/CRTReaderApplication.cpp
+++ b/src/CRTReaderApplication.cpp
@@ -73,12 +73,17 @@ CRTReaderApplication::generate_modules(const confmodel::Session* session) const
   for (auto rule : get_queue_rules()) {
     auto destination_class = rule->get_destination_class();
     auto data_type = rule->get_descriptor()->get_data_type();
-    // Why datahander here?
-    if (destination_class == "FDDataHandlerModule") {
+    // Why datahander here? It is the base class for several DataHandler types (e.g. FDDataHandlerModule,
+    // SNBDataHandlerModule)
+    if (destination_class == "DataHandlerModule") {
       if (data_type != "DataRequest") {
         dlh_input_qdesc = rule->get_descriptor();
       }
     }
+  }
+
+  if (dlh_input_qdesc == nullptr) {
+    throw(BadConf(ERS_HERE, "No data link handler input queue descriptor given"));
   }
 
   //

--- a/src/ReadoutApplication.cpp
+++ b/src/ReadoutApplication.cpp
@@ -121,7 +121,7 @@ ReadoutApplication::generate_modules(const confmodel::Session* session) const
   for (auto rule : get_queue_rules()) {
     auto destination_class = rule->get_destination_class();
     auto data_type = rule->get_descriptor()->get_data_type();
-    // Why datahander here?
+    // Why datahander here? It is the base class for several DataHandler types (e.g. FDDataHandlerModule, SNBDataHandlerModule)
     if (destination_class == "DataHandlerModule" || destination_class == dlh_class || destination_class == tph_class) {
       if (data_type == "DataRequest") {
         dlh_reqinput_qdesc = rule->get_descriptor();
@@ -133,6 +133,13 @@ ReadoutApplication::generate_modules(const confmodel::Session* session) const
     } else if (destination_class == "FragmentAggregatorModule") {
       fa_output_qdesc = rule->get_descriptor();
     }
+  }
+
+  if (dlh_input_qdesc == nullptr) {
+    throw(BadConf(ERS_HERE, "No data link handler input queue descriptor given"));
+  }
+  if (dlh_reqinput_qdesc == nullptr) {
+    throw(BadConf(ERS_HERE, "No data link handler request input queue descriptor given"));
   }
 
   //
@@ -155,6 +162,13 @@ ReadoutApplication::generate_modules(const confmodel::Session* session) const
     } else if (data_type == "TimeSync") {
       ts_net_desc = rule->get_descriptor();
     }
+  }
+
+  if (fa_net_desc == nullptr) {
+    throw(BadConf(ERS_HERE, "No Fragment Aggregator network descriptor given"));
+  }
+  if (ts_net_desc == nullptr && dlh_conf->get_generate_timesync()) {
+    throw(BadConf(ERS_HERE, "No Time Sync network descriptor given but time sync generation is enabled"));
   }
 
   // Create here the Queue on which all data fragments are forwarded to the fragment aggregator
@@ -281,7 +295,15 @@ ReadoutApplication::generate_modules(const confmodel::Session* session) const
   //
   std::vector<const confmodel::Connection*> tp_queues;
   if (get_tp_generation_enabled()) {
-
+    if (tp_input_qdesc == nullptr) {
+        throw(BadConf(ERS_HERE, "TP generation is enabled but no TP input queue descriptor given"));
+    }
+    if (tp_net_desc == nullptr) {
+        throw(BadConf(ERS_HERE, "TP generation is enabled but no TPSet network descriptor given"));
+    }
+    if (ta_net_desc == nullptr) {
+      throw(BadConf(ERS_HERE, "TP generation is enabled but no TriggerActivity network descriptor given"));
+    }
     // Create TP handler object
     auto tph_conf_obj = tph_conf->config_object();
     auto tpsrc_ids = get_tp_source_ids();


### PR DESCRIPTION
# Description

Readout Queue Descriptors use the base class "DataHandlerModule" for their destination module type, so CRTReaderApplication.cpp had the incorrect check for the DLH input queue.

Added several checks to throw a configuration error before trying to construct queues with possibly-null queue/network descriptors.


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

Tested using `generate_modules_test local-socket-1x1-config crt-data-source-01 config/daqsystemtest/example-configs.data.xml` as that was triggering the issue.

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

