### PR TITLE
Gcrone/pds schema fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(appmodel VERSION 4.0.0)
+project(appmodel VERSION 4.0.1)
 
 find_package(daq-cmake REQUIRED)
 

--- a/schema/appmodel/PDS.schema.xml
+++ b/schema/appmodel/PDS.schema.xml
@@ -86,6 +86,7 @@
  <file path="schema/confmodel/dunedaq.schema.xml"/>
  <file path="schema/appmodel/application.schema.xml"/>
  <file path="schema/appmodel/fdmodules.schema.xml"/>
+ <file path="schema/appmodel/hermes.schema.xml"/>
 </include>
 
 


### PR DESCRIPTION
# Description

PDS.schema.xml was missing an include file. This caused problems depending on whether the missing file had been included before PDS.schema.xml or not. This PR adds the missing include statement.

Addresses issue # 

Without this fix, running daqconf consolidate on np02-session from ehn1-daqconfigs branch mroda/test_branch would often produce a file which would cause an error in `oks_dump -f`. With this fix, the file produced by consolidate will be valid.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

