### PR TITLE
Revert "Updated trigger candidate maker configuration schema"

### DIFF
--- a/schema/appmodel/trigger.schema.xml
+++ b/schema/appmodel/trigger.schema.xml
@@ -215,11 +215,8 @@
   <attribute name="template_for" type="class" init-value="RandomTCMakerModule"/>
   <attribute name="trigger_rate_hz" description="Trigger rate (in Hz) for the RandomTCMaker to produce the TCs" type="float" init-value="1" is-not-null="yes"/>
   <attribute name="time_distribution" description="Type of distribution used for random timestamps (uniform or poisson)" type="enum" range="kUniform,kPoisson" init-value="kUniform" is-not-null="yes"/>
-  <attribute name="candidate_type_name" description="Enumerator name of the TC type, e.g. kTiming" type="string" init-value="kRandom" is-not-null="yes"/>
-  <attribute name="candidate_backshift_ts" type="s64" description="Time backshift applied to the TC central time at the creation of the TC" init-value="1000" is-not-null="yes"/>
-  <attribute name="candidate_window_before_ts" type="u32" description="Candidate extension before its central time" init-value="1000" is-not-null="yes"/>
-  <attribute name="candidate_window_after_ts" type="u32" description="Candidate extension after its central time" init-value="1000" is-not-null="yes"/>
-</class>
+  <relationship name="tc_readout" description="Configuration for the TC output type and the TC window size" class-type="TCReadoutMap" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
+ </class>
 
  <class name="RandomTCMakerModule">
   <superclass name="StandaloneTCMakerModule"/>


### PR DESCRIPTION
Reverts DUNE-DAQ/appmodel#259

Reverting due to failing integration tests, and need for additional updates on configurations there, in other integtests, and perhaps also dunedaq_conf_reader