### PR TITLE
Reapply "Updated trigger candidate maker configuration schema"

### DIFF
--- a/schema/appmodel/trigger.schema.xml
+++ b/schema/appmodel/trigger.schema.xml
@@ -215,8 +215,11 @@
   <attribute name="template_for" type="class" init-value="RandomTCMakerModule"/>
   <attribute name="trigger_rate_hz" description="Trigger rate (in Hz) for the RandomTCMaker to produce the TCs" type="float" init-value="1" is-not-null="yes"/>
   <attribute name="time_distribution" description="Type of distribution used for random timestamps (uniform or poisson)" type="enum" range="kUniform,kPoisson" init-value="kUniform" is-not-null="yes"/>
-  <relationship name="tc_readout" description="Configuration for the TC output type and the TC window size" class-type="TCReadoutMap" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
- </class>
+  <attribute name="candidate_type_name" description="Enumerator name of the TC type, e.g. kTiming" type="string" init-value="kRandom" is-not-null="yes"/>
+  <attribute name="candidate_backshift_ts" type="s64" description="Time backshift applied to the TC central time at the creation of the TC" init-value="1000" is-not-null="yes"/>
+  <attribute name="candidate_window_before_ts" type="u32" description="Candidate extension before its central time" init-value="1000" is-not-null="yes"/>
+  <attribute name="candidate_window_after_ts" type="u32" description="Candidate extension after its central time" init-value="1000" is-not-null="yes"/>
+</class>
 
  <class name="RandomTCMakerModule">
   <superclass name="StandaloneTCMakerModule"/>


### PR DESCRIPTION
This reverts commit 616d1e2c82fa8041dc971a78dc4bcd87c488082a.

See #259 for the original PR. Addresses https://github.com/DUNE-DAQ/trigger/issues/415 (see there for details). 

See https://github.com/DUNE-DAQ/trigger/pull/423 for general info on testing.


