### PR TITLE
Johnfreeman/prep release merged

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(appmodel VERSION 4.0.1)
+project(appmodel VERSION 4.0.2)
 
 find_package(daq-cmake REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(appmodel VERSION 4.0.0)
+project(appmodel VERSION 4.0.1)
 
 find_package(daq-cmake REQUIRED)
 

--- a/schema/appmodel/PDS.schema.xml
+++ b/schema/appmodel/PDS.schema.xml
@@ -86,6 +86,7 @@
  <file path="schema/confmodel/dunedaq.schema.xml"/>
  <file path="schema/appmodel/application.schema.xml"/>
  <file path="schema/appmodel/fdmodules.schema.xml"/>
+ <file path="schema/appmodel/hermes.schema.xml"/>
 </include>
 
 

--- a/schema/appmodel/trigger.schema.xml
+++ b/schema/appmodel/trigger.schema.xml
@@ -200,7 +200,7 @@
   <attribute name="trigger_rate_hz" description="Trigger rate (in Hz) for the RandomTCMaker to produce the TCs" type="float" init-value="1" is-not-null="yes"/>
   <attribute name="time_distribution" description="Type of distribution used for random timestamps (uniform or poisson)" type="enum" range="kUniform,kPoisson" init-value="kUniform" is-not-null="yes"/>
   <attribute name="candidate_type_name" description="Enumerator name of the TC type, e.g. kTiming" type="string" init-value="kRandom" is-not-null="yes"/>
-  <attribute name="candidate_backshift_ts" type="s32" init-value="1000" is-not-null="yes"/>
+  <attribute name="candidate_backshift_ts" type="s64" init-value="1000" is-not-null="yes"/>
   <attribute name="candidate_window_before_ts" type="u32" init-value="1000" is-not-null="yes"/>
   <attribute name="candidate_window_after_ts" type="u32" init-value="1000" is-not-null="yes"/>
 </class>

--- a/schema/appmodel/trigger.schema.xml
+++ b/schema/appmodel/trigger.schema.xml
@@ -200,7 +200,7 @@
   <attribute name="trigger_rate_hz" description="Trigger rate (in Hz) for the RandomTCMaker to produce the TCs" type="float" init-value="1" is-not-null="yes"/>
   <attribute name="time_distribution" description="Type of distribution used for random timestamps (uniform or poisson)" type="enum" range="kUniform,kPoisson" init-value="kUniform" is-not-null="yes"/>
   <attribute name="candidate_type_name" description="Enumerator name of the TC type, e.g. kTiming" type="string" init-value="kRandom" is-not-null="yes"/>
-  <attribute name="candidate_offset_ts" type="s64" init-value="1000" is-not-null="yes"/>
+  <attribute name="candidate_offset_ts" type="s32" init-value="1000" is-not-null="yes"/>
   <attribute name="candidate_window_before_ts" type="u32" init-value="1000" is-not-null="yes"/>
   <attribute name="candidate_window_after_ts" type="u32" init-value="1000" is-not-null="yes"/>
 </class>

--- a/schema/appmodel/trigger.schema.xml
+++ b/schema/appmodel/trigger.schema.xml
@@ -200,9 +200,9 @@
   <attribute name="trigger_rate_hz" description="Trigger rate (in Hz) for the RandomTCMaker to produce the TCs" type="float" init-value="1" is-not-null="yes"/>
   <attribute name="time_distribution" description="Type of distribution used for random timestamps (uniform or poisson)" type="enum" range="kUniform,kPoisson" init-value="kUniform" is-not-null="yes"/>
   <attribute name="candidate_type_name" description="Enumerator name of the TC type, e.g. kTiming" type="string" init-value="kRandom" is-not-null="yes"/>
-  <attribute name="candidate_backshift_ts" type="s64" init-value="1000" is-not-null="yes"/>
-  <attribute name="candidate_window_before_ts" type="u32" init-value="1000" is-not-null="yes"/>
-  <attribute name="candidate_window_after_ts" type="u32" init-value="1000" is-not-null="yes"/>
+  <attribute name="candidate_backshift_ts" type="s64" description="Time backshift applied to the TC central time at the creation of the TC" init-value="1000" is-not-null="yes"/>
+  <attribute name="candidate_window_before_ts" type="u32" description="Candidate extension before its central time" init-value="1000" is-not-null="yes"/>
+  <attribute name="candidate_window_after_ts" type="u32" description="Candidate extension after its central time" init-value="1000" is-not-null="yes"/>
 </class>
 
  <class name="RandomTCMakerModule">

--- a/schema/appmodel/trigger.schema.xml
+++ b/schema/appmodel/trigger.schema.xml
@@ -200,7 +200,7 @@
   <attribute name="trigger_rate_hz" description="Trigger rate (in Hz) for the RandomTCMaker to produce the TCs" type="float" init-value="1" is-not-null="yes"/>
   <attribute name="time_distribution" description="Type of distribution used for random timestamps (uniform or poisson)" type="enum" range="kUniform,kPoisson" init-value="kUniform" is-not-null="yes"/>
   <attribute name="candidate_type_name" description="Enumerator name of the TC type, e.g. kTiming" type="string" init-value="kRandom" is-not-null="yes"/>
-  <attribute name="candidate_offset_ts" type="s32" init-value="1000" is-not-null="yes"/>
+  <attribute name="candidate_backshift_ts" type="s32" init-value="1000" is-not-null="yes"/>
   <attribute name="candidate_window_before_ts" type="u32" init-value="1000" is-not-null="yes"/>
   <attribute name="candidate_window_after_ts" type="u32" init-value="1000" is-not-null="yes"/>
 </class>

--- a/schema/appmodel/trigger.schema.xml
+++ b/schema/appmodel/trigger.schema.xml
@@ -215,11 +215,8 @@
   <attribute name="template_for" type="class" init-value="RandomTCMakerModule"/>
   <attribute name="trigger_rate_hz" description="Trigger rate (in Hz) for the RandomTCMaker to produce the TCs" type="float" init-value="1" is-not-null="yes"/>
   <attribute name="time_distribution" description="Type of distribution used for random timestamps (uniform or poisson)" type="enum" range="kUniform,kPoisson" init-value="kUniform" is-not-null="yes"/>
-  <attribute name="candidate_type_name" description="Enumerator name of the TC type, e.g. kTiming" type="string" init-value="kRandom" is-not-null="yes"/>
-  <attribute name="candidate_backshift_ts" type="s64" description="Time backshift applied to the TC central time at the creation of the TC" init-value="1000" is-not-null="yes"/>
-  <attribute name="candidate_window_before_ts" type="u32" description="Candidate extension before its central time" init-value="1000" is-not-null="yes"/>
-  <attribute name="candidate_window_after_ts" type="u32" description="Candidate extension after its central time" init-value="1000" is-not-null="yes"/>
-</class>
+  <relationship name="tc_readout" description="Configuration for the TC output type and the TC window size" class-type="TCReadoutMap" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
+ </class>
 
  <class name="RandomTCMakerModule">
   <superclass name="StandaloneTCMakerModule"/>

--- a/schema/appmodel/trigger.schema.xml
+++ b/schema/appmodel/trigger.schema.xml
@@ -199,8 +199,11 @@
   <attribute name="template_for" type="class" init-value="RandomTCMakerModule"/>
   <attribute name="trigger_rate_hz" description="Trigger rate (in Hz) for the RandomTCMaker to produce the TCs" type="float" init-value="1" is-not-null="yes"/>
   <attribute name="time_distribution" description="Type of distribution used for random timestamps (uniform or poisson)" type="enum" range="kUniform,kPoisson" init-value="kUniform" is-not-null="yes"/>
-  <relationship name="tc_readout" description="Configuration for the TC output type and the TC window size" class-type="TCReadoutMap" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
- </class>
+  <attribute name="candidate_type_name" description="Enumerator name of the TC type, e.g. kTiming" type="string" init-value="kRandom" is-not-null="yes"/>
+  <attribute name="candidate_offset_ts" type="s64" init-value="1000" is-not-null="yes"/>
+  <attribute name="candidate_window_before_ts" type="u32" init-value="1000" is-not-null="yes"/>
+  <attribute name="candidate_window_after_ts" type="u32" init-value="1000" is-not-null="yes"/>
+</class>
 
  <class name="RandomTCMakerModule">
   <superclass name="StandaloneTCMakerModule"/>


### PR DESCRIPTION
With `fddaq-v5.5.0` now cut, this source branch consists of a fork of the `develop` branch with `prep-release/fddaq-v5.5.0` merged in (i.e., this will be a fast-forward merge which brings the `fddaq-v5.5.0` code into `develop`). Over the weekend a test nightly was created, `MRGFD_DEV_251213_A9`, in which all the `johnfreeman/prep_release_merged` branches were used, and if I `pip install -U . ` the `johnfreeman/prep_release_merged` branch of `drunc`, integration tests with it look fine. 

# Description

_If full decription and testing details are included on a parent issue, please link to that here._
See issue # for details

_Otherwise, please include a summary of the change and which issue is fixed (if any).
Include relevant motivation and context, including a target environment and dunedaq version if known.
Also list any dependencies that are required for this change._
Addresses issue # 

_Please also include instructions for how a reviewer can test your changes._


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

