### PR TITLE
Gcrone/managed object

### DIFF
--- a/schema/appmodel/application.schema.xml
+++ b/schema/appmodel/application.schema.xml
@@ -80,7 +80,7 @@
 
 <oks-schema>
 
-<info name="" type="" num-of-items="66" oks-format="schema" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20230616T091343" last-modified-by="eflumerf" last-modified-on="ironvirt9.mshome.net" last-modification-time="20251104T211957"/>
+<info name="" type="" num-of-items="67" oks-format="schema" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20230616T091343" last-modified-by="gjc" last-modified-on="latitude" last-modification-time="20260217T151630"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
@@ -105,11 +105,15 @@
  <class name="DFApplication">
   <superclass name="SmartDaqApplication"/>
   <superclass name="Resource"/>
+  <superclass name="ManagedObject"/>
   <relationship name="trb" description="Configuration of the TRB to be generated my get_modules()" class-type="TRBConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <relationship name="data_writers" class-type="DataWriterConf" low-cc="one" high-cc="many" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <relationship name="uses" class-type="DFHWConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <method name="generate_modules" description="Generate DaqModule dal objects for streams of the application on the fly">
    <method-implementation language="c++" prototype="void generate_modules(const confmodel::Session*) const override" body=""/>
+  </method>
+  <method name="object_tags" description="">
+   <method-implementation language="c++" prototype="std::set&lt;std::string&gt; object_tags() const override" body=""/>
   </method>
  </class>
 

--- a/src/DFApplication.cpp
+++ b/src/DFApplication.cpp
@@ -195,7 +195,7 @@ DFApplication::object_tags() const {
   auto host = get_runs_on()->get_runs_on()->UID();
   for (auto writer : get_data_writers()) {
     auto path = writer->get_data_store_params()->get_directory_path();
-    tags.insert(host+"/"+path);
+    tags.insert("storage:"+host+":"+path);
   }
   return tags;
 }

--- a/src/DFApplication.cpp
+++ b/src/DFApplication.cpp
@@ -123,7 +123,7 @@ DFApplication::object_tags() const {
   auto host = get_runs_on()->get_runs_on()->UID();
   for (auto writer : get_data_writers()) {
     auto path = writer->get_data_store_params()->get_directory_path();
-    tags.insert("storage:"+host+":"+path);
+    tags.insert(fmt::format("storage:{}:{}", host, path));
   }
   return tags;
 }

--- a/src/DFApplication.cpp
+++ b/src/DFApplication.cpp
@@ -189,6 +189,17 @@ fill_sourceid_object_from_app(const ConfigObjectFactory& obj_fac,
   sidNetObj.set_objs("source_ids", source_id_objs);
 }
 
+std::set<std::string>
+DFApplication::object_tags() const {
+  std::set<std::string> tags;
+  auto host = get_runs_on()->get_runs_on()->UID();
+  for (auto writer : get_data_writers()) {
+    auto path = writer->get_data_store_params()->get_directory_path();
+    tags.insert(host+"/"+path);
+  }
+  return tags;
+}
+
 void
 DFApplication::generate_modules(const confmodel::Session* session) const
 {


### PR DESCRIPTION
# Description

Try making `DFApplication` a `ManagedObject` with its own implementation of `object_tags` that generates a tag for each `DataWriter`

Relies on PR https://github.com/DUNE-DAQ/confmodel/pull/89

_Please also include instructions for how a reviewer can test your changes._


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

