### PR TITLE
CRT topology change

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(appmodel VERSION 5.0.0)
+project(appmodel VERSION 5.0.1)
 
 find_package(daq-cmake REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(fmt REQUIRED)
 
 find_package(Boost COMPONENTS unit_test_framework program_options REQUIRED)
 
-daq_add_dal_library(application.schema.xml hermes.schema.xml fdmodules.schema.xml trigger.schema.xml wiec.schema.xml PDS.schema.xml tde.schema.xml CTB.schema.xml CIB.schema.xml
+daq_add_dal_library(application.schema.xml hermes.schema.xml fdmodules.schema.xml trigger.schema.xml wiec.schema.xml socket.schema.xml PDS.schema.xml tde.schema.xml CTB.schema.xml CIB.schema.xml
   NAMESPACE dunedaq::appmodel DEP_PKGS confmodel
   SOURCES
   ConfigurationHelper.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ daq_add_dal_library(application.schema.xml hermes.schema.xml fdmodules.schema.xm
   SOURCES
   ConfigurationHelper.cpp
 	ConfigObjectFactory.cpp
-	CRTReaderApplication.cpp
+	CRTFrameBuilderApplication.cpp
 	CTBApplication.cpp
 	DaphneApplication.cpp
 	DFApplication.cpp

--- a/schema/appmodel/application.schema.xml
+++ b/schema/appmodel/application.schema.xml
@@ -94,7 +94,6 @@
   <relationship name="detector_frame_builder" class-type="DetectorFrameBuilderConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <relationship name="data_writer" class-type="SocketDataWriterConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <relationship name="detector_connections" class-type="DetectorToDaqConnection" low-cc="zero" high-cc="many" is-composite="no" is-exclusive="no" is-dependent="no"/>
-  <relationship name="callback_desc" class-type="DataMoveCallbackDescriptor" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <method name="generate_modules" description="Generate daq module dal objects for streams of the CRTFrameBuilderApplication on the fly">
    <method-implementation language="c++" prototype="void generate_modules(std::shared_ptr&lt;appmodel::ConfigurationHelper&gt;) const override" body=""/>
   </method>
@@ -199,7 +198,7 @@
  <class name="DetectorFrameBuilderModule" is-abstract="yes">
   <superclass name="DaqModule"/>
   <relationship name="configuration" class-type="DetectorFrameBuilderConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
-  <relationship name="connections" class-type="DetectorToDaqConnection" low-cc="one" high-cc="many" is-composite="yes" is-exclusive="no" is-dependent="no"/>
+  <relationship name="connection" class-type="DetectorToDaqConnection" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
  </class> 
 
  <class name="DataRecorderConf">
@@ -537,8 +536,7 @@
  <class name="SocketDataWriterModule">
   <superclass name="DaqModule"/>
   <relationship name="configuration" class-type="SocketDataWriterConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
-  <relationship name="connections" class-type="SocketDetectorToDaqConnection" low-cc="one" high-cc="many" is-composite="yes" is-exclusive="no" is-dependent="no"/>
-  <relationship name="raw_data_callbacks" description="Configurations for raw data callbacks" class-type="DataMoveCallbackConf" low-cc="one" high-cc="many" is-composite="no" is-exclusive="no" is-dependent="no"/>
+  <relationship name="connection" class-type="SocketDetectorToDaqConnection" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
  </class>
 
  <class name="SocketDetectorToDaqConnection">

--- a/schema/appmodel/application.schema.xml
+++ b/schema/appmodel/application.schema.xml
@@ -80,22 +80,22 @@
 
 <oks-schema>
 
-<info name="" type="" num-of-items="70" oks-format="schema" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20230616T091343" last-modified-by="dergonul" last-modified-on="np04-srv-015.cern.ch" last-modification-time="20260213T122408"/>
+<info name="" type="" num-of-items="72" oks-format="schema" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20230616T091343" last-modified-by="dergonul" last-modified-on="np04-srv-015.cern.ch" last-modification-time="20260319T161203"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
 </include>
 
 
- <class name="CRTReaderApplication">
+ <class name="CRTFrameBuilderApplication">
   <superclass name="ResourceSetDisableAND"/>
   <superclass name="SmartDaqApplication"/>
   <attribute name="application_name" type="string" init-value="daq_application" is-not-null="yes"/>
-  <relationship name="data_reader" class-type="DataReaderConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
+  <relationship name="detector_frame_builder" class-type="DetectorFrameBuilderConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <relationship name="data_writer" class-type="SocketDataWriterConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <relationship name="detector_connections" class-type="DetectorToDaqConnection" low-cc="zero" high-cc="many" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <relationship name="callback_desc" class-type="DataMoveCallbackDescriptor" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
-  <method name="generate_modules" description="Generate daq module dal objects for streams of the CRTReaderApplication on the fly">
+  <method name="generate_modules" description="Generate daq module dal objects for streams of the CRTFrameBuilderApplication on the fly">
    <method-implementation language="c++" prototype="void generate_modules(std::shared_ptr&lt;appmodel::ConfigurationHelper&gt;) const override" body=""/>
   </method>
   <method name="contained_resources" description="">
@@ -191,6 +191,16 @@
   <relationship name="connections" class-type="DetectorToDaqConnection" low-cc="one" high-cc="many" is-composite="yes" is-exclusive="no" is-dependent="no"/>
   <relationship name="raw_data_callbacks" description="Configurations for raw data callbacks" class-type="DataMoveCallbackConf" low-cc="one" high-cc="many" is-composite="no" is-exclusive="no" is-dependent="no"/>
  </class>
+
+ <class name="DetectorFrameBuilderConf">
+  <attribute name="template_for" description="OKS class of the DetectorFrameBuilderModule that this config is a template for" type="class" init-value="DetectorFrameBuilderModule" is-not-null="yes"/>
+ </class>
+
+ <class name="DetectorFrameBuilderModule" is-abstract="yes">
+  <superclass name="DaqModule"/>
+  <relationship name="configuration" class-type="DetectorFrameBuilderConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
+  <relationship name="connections" class-type="DetectorToDaqConnection" low-cc="one" high-cc="many" is-composite="yes" is-exclusive="no" is-dependent="no"/>
+ </class> 
 
  <class name="DataRecorderConf">
   <attribute name="output_file" type="string"/>
@@ -405,8 +415,8 @@
   <attribute name="capacity" type="u32" init-value="100" is-not-null="yes"/>
   <attribute name="data_type" description="string identifying type of data transferred through this queue" type="string" is-not-null="yes"/>
  </class>
-
- <class name="DataMoveCallbackConf">
+ 
+  <class name="DataMoveCallbackConf">
   <attribute name="source_id" type="u32" init-value="0" is-not-null="yes"/>
   <attribute name="data_type" description="Name of the output data type. Should be defined via a call to DUNE_DAQ_TYPESTRING" type="string" init-value="WIBEthFrame"/>
  </class>

--- a/schema/appmodel/application.schema.xml
+++ b/schema/appmodel/application.schema.xml
@@ -80,7 +80,7 @@
 
 <oks-schema>
 
-<info name="" type="" num-of-items="66" oks-format="schema" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20230616T091343" last-modified-by="eflumerf" last-modified-on="ironvirt9.mshome.net" last-modification-time="20251104T211957"/>
+<info name="" type="" num-of-items="68" oks-format="schema" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20230616T091343" last-modified-by="dergonul" last-modified-on="np04-srv-015.cern.ch" last-modification-time="20260213T122408"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
@@ -91,8 +91,8 @@
   <superclass name="ResourceSetDisableAND"/>
   <superclass name="SmartDaqApplication"/>
   <attribute name="application_name" type="string" init-value="daq_application" is-not-null="yes"/>
-  <relationship name="data_writers" class-type="SocketDataWriterConf" low-cc="one" high-cc="many" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <relationship name="data_reader" class-type="DataReaderConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
+  <relationship name="data_writer" class-type="SocketDataWriterConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <relationship name="detector_connections" class-type="DetectorToDaqConnection" low-cc="zero" high-cc="many" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <method name="generate_modules" description="Generate daq module dal objects for streams of the CRTReaderApplication on the fly">
    <method-implementation language="c++" prototype="void generate_modules(const confmodel::Session*) const override" body=""/>
@@ -513,7 +513,11 @@
  <class name="SocketDataWriterModule">
   <superclass name="DaqModule"/>
   <relationship name="configuration" class-type="SocketDataWriterConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
-  <relationship name="connections" class-type="NetworkDetectorToDaqConnection" low-cc="one" high-cc="many" is-composite="yes" is-exclusive="no" is-dependent="no"/>
+  <relationship name="connections" class-type="SocketDetectorToDaqConnection" low-cc="one" high-cc="many" is-composite="yes" is-exclusive="no" is-dependent="no"/>
+ </class>
+
+ <class name="SocketDetectorToDaqConnection">
+  <superclass name="NetworkDetectorToDaqConnection"/>
  </class>
 
  <class name="SourceIDConf">

--- a/schema/appmodel/application.schema.xml
+++ b/schema/appmodel/application.schema.xml
@@ -80,7 +80,7 @@
 
 <oks-schema>
 
-<info name="" type="" num-of-items="68" oks-format="schema" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20230616T091343" last-modified-by="dergonul" last-modified-on="np04-srv-015.cern.ch" last-modification-time="20260213T122408"/>
+<info name="" type="" num-of-items="70" oks-format="schema" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20230616T091343" last-modified-by="dergonul" last-modified-on="np04-srv-015.cern.ch" last-modification-time="20260213T122408"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>

--- a/schema/appmodel/application.schema.xml
+++ b/schema/appmodel/application.schema.xml
@@ -528,6 +528,7 @@
   <superclass name="DaqModule"/>
   <relationship name="configuration" class-type="SocketDataWriterConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <relationship name="connections" class-type="SocketDetectorToDaqConnection" low-cc="one" high-cc="many" is-composite="yes" is-exclusive="no" is-dependent="no"/>
+  <relationship name="raw_data_callbacks" description="Configurations for raw data callbacks" class-type="DataMoveCallbackConf" low-cc="one" high-cc="many" is-composite="no" is-exclusive="no" is-dependent="no"/>
  </class>
 
  <class name="SocketDetectorToDaqConnection">

--- a/schema/appmodel/fdmodules.schema.xml
+++ b/schema/appmodel/fdmodules.schema.xml
@@ -80,7 +80,7 @@
 
 <oks-schema>
 
-<info name="" type="" num-of-items="30" oks-format="schema" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20230616T091343" last-modified-by="dergonul" last-modified-on="np04-srv-015.cern.ch" last-modification-time="20260212T162900"/>
+<info name="" type="" num-of-items="32" oks-format="schema" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20230616T091343" last-modified-by="dergonul" last-modified-on="np04-srv-015.cern.ch" last-modification-time="20260212T162900"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>

--- a/schema/appmodel/fdmodules.schema.xml
+++ b/schema/appmodel/fdmodules.schema.xml
@@ -80,7 +80,7 @@
 
 <oks-schema>
 
-<info name="" type="" num-of-items="32" oks-format="schema" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20230616T091343" last-modified-by="dergonul" last-modified-on="np04-srv-015.cern.ch" last-modification-time="20260212T162900"/>
+<info name="" type="" num-of-items="32" oks-format="schema" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20230616T091343" last-modified-by="dergonul" last-modified-on="np04-srv-015.cern.ch" last-modification-time="20260319T162022"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
@@ -88,24 +88,24 @@
 </include>
 
 
- <class name="CRTBernReaderConf">
-  <superclass name="CRTReaderConf"/>
+ <class name="CRTBernFrameBuilderConf">
+  <superclass name="CRTFrameBuilderConf"/>
  </class>
 
- <class name="CRTBernReaderModule">
-  <superclass name="DataReaderModule"/>
+ <class name="CRTBernFrameBuilderModule">
+  <superclass name="DetectorFrameBuilderModule"/>
  </class>
 
- <class name="CRTGrenobleReaderConf">
-  <superclass name="CRTReaderConf"/>
+ <class name="CRTGrenobleFrameBuilderConf">
+  <superclass name="CRTFrameBuilderConf"/>
  </class>
 
- <class name="CRTGrenobleReaderModule">
-  <superclass name="DataReaderModule"/>
+ <class name="CRTGrenobleFrameBuilderModule">
+  <superclass name="DetectorFrameBuilderModule"/>
  </class>
 
- <class name="CRTReaderConf">
-  <superclass name="DataReaderConf"/>
+ <class name="CRTFrameBuilderConf">
+  <superclass name="DetectorFrameBuilderConf"/>
  </class>
 
  <class name="DPDKPortConfiguration">

--- a/schema/appmodel/fdmodules.schema.xml
+++ b/schema/appmodel/fdmodules.schema.xml
@@ -80,7 +80,7 @@
 
 <oks-schema>
 
-<info name="" type="" num-of-items="33" oks-format="schema" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20230616T091343" last-modified-by="eflumerf" last-modified-on="ironvirt9.mshome.net" last-modification-time="20251104T211957"/>
+<info name="" type="" num-of-items="30" oks-format="schema" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20230616T091343" last-modified-by="dergonul" last-modified-on="np04-srv-015.cern.ch" last-modification-time="20260212T162900"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
@@ -89,7 +89,7 @@
 
 
  <class name="CRTBernReaderConf">
-  <superclass name="DataReaderConf"/>
+  <superclass name="CRTReaderConf"/>
  </class>
 
  <class name="CRTBernReaderModule">
@@ -97,7 +97,7 @@
  </class>
 
  <class name="CRTGrenobleReaderConf">
-  <superclass name="DataReaderConf"/>
+  <superclass name="CRTReaderConf"/>
  </class>
 
  <class name="CRTGrenobleReaderModule">
@@ -151,10 +151,6 @@
 
  <class name="FakeDataSender">
   <superclass name="NWDetDataSender"/>
- </class>
-
- <class name="FakeSocketWriterModule">
-  <superclass name="SocketDataWriterModule"/>
  </class>
 
  <class name="FelixCardControllerModule">
@@ -245,8 +241,6 @@
 
  <class name="SocketReaderConf">
   <superclass name="DataReaderConf"/>
-  <attribute name="socket_type" description="Socket type" type="enum" range="TCP,UDP" init-value="UDP" is-not-null="yes"/>
-  <attribute name="local_ip" description="Local IP address" type="string" init-value="127.0.0.1" is-not-null="yes"/>
  </class>
 
  <class name="SocketReaderModule">
@@ -259,8 +253,6 @@
 
  <class name="SocketWriterConf">
   <superclass name="SocketDataWriterConf"/>
-  <attribute name="socket_type" description="Socket type" type="enum" range="TCP,UDP" init-value="UDP" is-not-null="yes"/>
-  <attribute name="remote_ip" description="Remote IP address" type="string" init-value="127.0.0.1" is-not-null="yes"/>
  </class>
 
  <class name="SocketWriterModule">

--- a/schema/appmodel/socket.schema.xml
+++ b/schema/appmodel/socket.schema.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="ASCII"?>
+
+<!-- oks-schema version 2.2 -->
+
+
+<!DOCTYPE oks-schema [
+  <!ELEMENT oks-schema (info, (include)?, (comments)?, (class)+)>
+  <!ELEMENT info EMPTY>
+  <!ATTLIST info
+      name CDATA #IMPLIED
+      type CDATA #IMPLIED
+      num-of-items CDATA #REQUIRED
+      oks-format CDATA #FIXED "schema"
+      oks-version CDATA #REQUIRED
+      created-by CDATA #IMPLIED
+      created-on CDATA #IMPLIED
+      creation-time CDATA #IMPLIED
+      last-modified-by CDATA #IMPLIED
+      last-modified-on CDATA #IMPLIED
+      last-modification-time CDATA #IMPLIED
+  >
+  <!ELEMENT include (file)+>
+  <!ELEMENT file EMPTY>
+  <!ATTLIST file
+      path CDATA #REQUIRED
+  >
+  <!ELEMENT comments (comment)+>
+  <!ELEMENT comment EMPTY>
+  <!ATTLIST comment
+      creation-time CDATA #REQUIRED
+      created-by CDATA #REQUIRED
+      created-on CDATA #REQUIRED
+      author CDATA #REQUIRED
+      text CDATA #REQUIRED
+  >
+  <!ELEMENT class (superclass | attribute | relationship | method)*>
+  <!ATTLIST class
+      name CDATA #REQUIRED
+      description CDATA ""
+      is-abstract (yes|no) "no"
+  >
+  <!ELEMENT superclass EMPTY>
+  <!ATTLIST superclass name CDATA #REQUIRED>
+  <!ELEMENT attribute EMPTY>
+  <!ATTLIST attribute
+      name CDATA #REQUIRED
+      description CDATA ""
+      type (bool|s8|u8|s16|u16|s32|u32|s64|u64|float|double|date|time|string|uid|enum|class) #REQUIRED
+      range CDATA ""
+      format (dec|hex|oct) "dec"
+      is-multi-value (yes|no) "no"
+      init-value CDATA ""
+      is-not-null (yes|no) "no"
+      ordered (yes|no) "no"
+  >
+  <!ELEMENT relationship EMPTY>
+  <!ATTLIST relationship
+      name CDATA #REQUIRED
+      description CDATA ""
+      class-type CDATA #REQUIRED
+      low-cc (zero|one) #REQUIRED
+      high-cc (one|many) #REQUIRED
+      is-composite (yes|no) #REQUIRED
+      is-exclusive (yes|no) #REQUIRED
+      is-dependent (yes|no) #REQUIRED
+      ordered (yes|no) "no"
+  >
+  <!ELEMENT method (method-implementation*)>
+  <!ATTLIST method
+      name CDATA #REQUIRED
+      description CDATA ""
+  >
+  <!ELEMENT method-implementation EMPTY>
+  <!ATTLIST method-implementation
+      language CDATA #REQUIRED
+      prototype CDATA #REQUIRED
+      body CDATA ""
+  >
+]>
+
+<oks-schema>
+
+<info name="" type="" num-of-items="1" oks-format="schema" oks-version="862f2957270" created-by="dergonul" created-on="np04-srv-015.cern.ch" creation-time="20260318T105913" last-modified-by="dergonul" last-modified-on="np04-srv-015.cern.ch" last-modification-time="20260318T110035"/>
+
+<include>
+ <file path="schema/appmodel/application.schema.xml"/>
+</include>
+
+
+ <class name="SocketDataSender">
+  <superclass name="NWDetDataSender"/>
+  <attribute name="socket_type" description="Socket type" type="enum" range="TCP,UDP" init-value="UDP" is-not-null="yes"/>
+  <attribute name="local_port" type="u32" range="0..65535" init-value="0" is-not-null="yes"/>
+  <attribute name="remote_port" type="u32" range="1..65535" init-value="20001" is-not-null="yes"/>
+ </class>
+
+</oks-schema>

--- a/schema/appmodel/wiec.schema.xml
+++ b/schema/appmodel/wiec.schema.xml
@@ -80,7 +80,7 @@
 
 <oks-schema>
 
-<info name="" type="" num-of-items="8" oks-format="schema" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20230616T091343" last-modified-by="dergonul" last-modified-on="np04-srv-015.cern.ch" last-modification-time="20260212T161706"/>
+<info name="" type="" num-of-items="7" oks-format="schema" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20230616T091343" last-modified-by="dergonul" last-modified-on="np04-srv-015.cern.ch" last-modification-time="20260318T110034"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
@@ -118,13 +118,6 @@
   <attribute name="strobe_length" description="Length of strobe in 64MHz periods (pulser length 0-255)" type="u8" init-value="255" is-not-null="yes"/>
   <attribute name="line_driver" description="0 (Default), 1 (Short), 2 (25 m warm), 3 (35 m warm), 4 (25 m cold), 5 (35 m cold). Can submit up to 2 values for the two COLDATA." type="u8" is-multi-value="yes"/>
   <attribute name="pulse_channels" description="Array of up to 16 true/false values, for whether to send pulser to each corresponding channel per LArASIC." type="bool" is-multi-value="yes"/>
- </class>
-
- <class name="SocketDataSender">
-  <superclass name="NWDetDataSender"/>
-  <attribute name="socket_type" description="Socket type" type="enum" range="TCP,UDP" init-value="UDP" is-not-null="yes"/>
-  <attribute name="local_port" type="u32" is-not-null="yes" range="0..65535" init-value="0"/>
-  <attribute name="remote_port" type="u32" is-not-null="yes" range="1..65535" init-value="20001"/>
  </class>
 
  <class name="WIBModule">

--- a/schema/appmodel/wiec.schema.xml
+++ b/schema/appmodel/wiec.schema.xml
@@ -80,7 +80,7 @@
 
 <oks-schema>
 
-<info name="" type="" num-of-items="8" oks-format="schema" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20230616T091343" last-modified-by="gjc" last-modified-on="latitude" last-modification-time="20250818T143705"/>
+<info name="" type="" num-of-items="8" oks-format="schema" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20230616T091343" last-modified-by="dergonul" last-modified-on="np04-srv-015.cern.ch" last-modification-time="20260212T161706"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
@@ -122,9 +122,9 @@
 
  <class name="SocketDataSender">
   <superclass name="NWDetDataSender"/>
-  <attribute name="link_id" type="u32" is-not-null="yes"/>
-  <attribute name="port" type="u32" init-value="1234" is-not-null="yes"/>
-  <attribute name="control_host" type="string" init-value="localhost" is-not-null="yes"/>
+  <attribute name="socket_type" description="Socket type" type="enum" range="TCP,UDP" init-value="UDP" is-not-null="yes"/>
+  <attribute name="local_port" type="u32" is-not-null="yes" range="0..65535" init-value="0"/>
+  <attribute name="remote_port" type="u32" is-not-null="yes" range="1..65535" init-value="20001"/>
  </class>
 
  <class name="WIBModule">

--- a/src/CRTFrameBuilderApplication.cpp
+++ b/src/CRTFrameBuilderApplication.cpp
@@ -1,14 +1,14 @@
 /**
- * @file CRTReaderApplication.cpp
+ * @file CRTFrameBuilderApplication.cpp
  *
- * Implementation of CRTReaderApplication's generate_modules dal method
+ * Implementation of CRTFrameBuilderApplication's generate_modules dal method
  *
  * This is part of the DUNE DAQ Software Suite, copyright 2023.
  * Licensing/copyright details are in the COPYING file that you should have
  * received with this code.
  */
 
-#include "appmodel/CRTReaderApplication.hpp"
+#include "appmodel/CRTFrameBuilderApplication.hpp"
 
 #include "appmodel/appmodelIssues.hpp"
 
@@ -36,12 +36,12 @@
 namespace dunedaq::appmodel {
 
 std::vector<const confmodel::Resource*>
-CRTReaderApplication::contained_resources() const {
+CRTFrameBuilderApplication::contained_resources() const {
   return to_resources(get_detector_connections());
 }
 
 void
-  CRTReaderApplication::generate_modules(std::shared_ptr<appmodel::ConfigurationHelper> helper) const
+  CRTFrameBuilderApplication::generate_modules(std::shared_ptr<appmodel::ConfigurationHelper> helper) const
 {
 
   TLOG_DEBUG(6) << "Generating modules for application " << this->UID();
@@ -55,11 +55,11 @@ void
   //
 
   // Data reader  
-  const auto reader_conf = get_data_reader();
-  if (reader_conf == nullptr) {
-    throw(BadConf(ERS_HERE, "No DataReaderModule configuration given"));
-  }  
-  const std::string reader_class = reader_conf->get_template_for();
+  //const auto reader_conf = get_data_reader();
+  //if (reader_conf == nullptr) {
+  //  throw(BadConf(ERS_HERE, "No DataReaderModule configuration given"));
+  //}  
+  //const std::string reader_class = reader_conf->get_template_for();
   
   // Data writer  
   const auto writer_conf = get_data_writer();
@@ -126,21 +126,21 @@ void
     //
 
     //
-    // Instantiate DataReaderModule of type CRTBernReaderModule/CRTGrenobleReaderModule
+    // Instantiate DataReaderModule of type CRTBernFrameBuilderModule/CRTGrenobleFrameBuilderModule
     //
 
     // Create the Data reader object
 
-    std::string reader_uid(fmt::format("crtreader-{}-{}", this->UID(), std::to_string(conn_idx++)));
-    TLOG_DEBUG(6) << fmt::format("creating OKS configuration object for Data reader class {} with id {}", reader_class, reader_uid);
-    auto reader_obj = obj_fac.create(reader_class, reader_uid);
-
-    // Populate configuration and interfaces
-    reader_obj.set_obj("configuration", &reader_conf->config_object());
-    reader_obj.set_objs("connections", { &d2d_conn->config_object() });
-    reader_obj.set_objs("raw_data_callbacks", raw_data_callback_objs);
-
-    modules.push_back(obj_fac.get_dal<confmodel::DaqModule>(reader_obj.UID()));
+    //std::string reader_uid(fmt::format("crtframebuilder-{}-{}", this->UID(), std::to_string(conn_idx++)));
+    //TLOG_DEBUG(6) << fmt::format("creating OKS configuration object for Data reader class {} with id {}", reader_class, reader_uid);
+    //auto reader_obj = obj_fac.create(reader_class, reader_uid);
+//
+    //// Populate configuration and interfaces
+    //reader_obj.set_obj("configuration", &reader_conf->config_object());
+    //reader_obj.set_objs("connections", { &d2d_conn->config_object() });
+    //reader_obj.set_objs("raw_data_callbacks", raw_data_callback_objs);
+//
+    //modules.push_back(obj_fac.get_dal<confmodel::DaqModule>(reader_obj.UID()));
 
     //-----------------------------------------------------------------
     //

--- a/src/CRTFrameBuilderApplication.cpp
+++ b/src/CRTFrameBuilderApplication.cpp
@@ -12,18 +12,20 @@
 
 #include "appmodel/appmodelIssues.hpp"
 
-#include "appmodel/DataReaderConf.hpp"
+#include "appmodel/DetectorFrameBuilderConf.hpp"
 #include "appmodel/SocketWriterConf.hpp"
 #include "appmodel/SocketWriterModule.hpp"
-#include "appmodel/DataMoveCallbackConf.hpp"
 #include "appmodel/QueueConnectionRule.hpp"
 #include "appmodel/QueueDescriptor.hpp"
+#include "appmodel/SocketDetectorToDaqConnection.hpp"
 
 #include "ConfigObjectFactory.hpp"
 
 #include "confmodel/Connection.hpp"
 #include "confmodel/DetectorStream.hpp"
 #include "confmodel/DetectorToDaqConnection.hpp"
+#include "confmodel/DetDataSender.hpp"
+#include "confmodel/DetDataReceiver.hpp"
 
 #include "logging/Logging.hpp"
 
@@ -54,12 +56,12 @@ void
   // Extract basic configuration objects
   //
 
-  // Data reader  
-  //const auto reader_conf = get_data_reader();
-  //if (reader_conf == nullptr) {
-  //  throw(BadConf(ERS_HERE, "No DataReaderModule configuration given"));
-  //}  
-  //const std::string reader_class = reader_conf->get_template_for();
+  // Detector frame builder
+  const auto det_frame_builder_conf = get_detector_frame_builder();
+  if (det_frame_builder_conf == nullptr) {
+    throw(BadConf(ERS_HERE, "No DetectorFrameBuilderModule configuration given"));
+  }  
+  const std::string builder_class = det_frame_builder_conf->get_template_for();
   
   // Data writer  
   const auto writer_conf = get_data_writer();
@@ -69,100 +71,129 @@ void
   const std::string writer_class = writer_conf->get_template_for();
 
   //
-  // Get the callback descriptor
+  // Process the queue rules looking for inputs to our socket writer modules
   //
-  const DataMoveCallbackDescriptor* raw_data_callback_desc = get_callback_desc();
-
-  if (raw_data_callback_desc == nullptr) {
-    throw(BadConf(ERS_HERE, "No Raw Data Callback descriptor given"));
+  const QueueDescriptor* crtframebuilder_output_qdesc = nullptr;
+  auto queue_rules = get_queue_rules();
+  if (queue_rules.size() != 1) {
+    throw(BadConf(ERS_HERE, "Strictly 1 queue rule is expected"));
   }
+  crtframebuilder_output_qdesc = queue_rules[0]->get_descriptor();
 
   //
   // Scan Detector 2 DAQ connections to extract sender, receiver and stream information
   //
 
   // Loop over the detector to daq connections and generate:
-  // - One data reader per detector connection
-  // - One data writer per detector connection
-
-  uint16_t conn_idx = 0; // NOLINT(build/unsigned)
+  // - One detector frame builder per data sender
+  // - One data writer per data sender
+  // - One queue per data sender
 
   for (auto d2d_conn : get_detector_connections()) {
 
+    auto d2d_conn_uid = d2d_conn->UID();
+
     // Are we sure?
     if (helper->is_disabled(d2d_conn)) {
-      TLOG_DEBUG(7) << "Ignoring disabled DetectorToDaqConnection " << d2d_conn->UID();
+      TLOG_DEBUG(7) << "Ignoring disabled DetectorToDaqConnection " << d2d_conn_uid;
       continue;
     }
 
-    TLOG_DEBUG(6) << "Processing DetectorToDaqConnection " << d2d_conn->UID();
-    
-    std::vector<const confmodel::DetectorStream*> enabled_det_streams;
-    // Loop over streams
-    for (auto stream : d2d_conn->streams()) {
+    TLOG_DEBUG(6) << "Processing DetectorToDaqConnection " << d2d_conn_uid;
 
+    auto receiver = d2d_conn->receiver();
+
+    uint16_t sender_idx = 0; // NOLINT(build/unsigned)
+
+    // Loop over senders
+    for (auto sender : d2d_conn->senders()) {
+      
       // Are we sure?
-      if (helper->is_disabled(stream)) {
-        TLOG_DEBUG(7) << "Ignoring disabled DetectorStream " << stream->UID();
+      if (helper->is_disabled(sender)) {
+        TLOG_DEBUG(7) << "Ignoring disabled DataSender " << sender->UID();
         continue;
       }
 
-      enabled_det_streams.push_back(stream);
-    }
-
-    // Create the raw data callbacks
-    std::vector<const conffwk::ConfigObject*> raw_data_callback_objs;
-
-    // Create data queues
-    for (auto ds : enabled_det_streams) {
-      conffwk::ConfigObject callback_obj = obj_fac.create_callback_sid_obj(raw_data_callback_desc, ds->get_source_id());
-      const auto* callback_conf = obj_fac.get_dal<DataMoveCallbackConf>(callback_obj.UID());
-      raw_data_callback_objs.push_back(&callback_conf->config_object());
-    }  
+      
+      bool has_enabled_det_stream = false;
+      // Loop over streams
+      for (auto stream : sender->get_streams()) {
         
-    //-----------------------------------------------------------------
-    //
-    // Create DataReaderModule object
-    //
+        // Are we sure?
+        if (helper->is_disabled(stream)) {
+          TLOG_DEBUG(7) << "Ignoring disabled DetectorStream " << stream->UID();
+          continue;
+        }
 
-    //
-    // Instantiate DataReaderModule of type CRTBernFrameBuilderModule/CRTGrenobleFrameBuilderModule
-    //
+        has_enabled_det_stream = true;
+        break;
+      }
+      
+      if (!has_enabled_det_stream) {
+        continue;
+      }
 
-    // Create the Data reader object
+      const auto sender_idx_str = std::to_string(sender_idx);
+      
+      // Create a connection that is dedicated to this sender
+      std::string sender_conn_uid(d2d_conn_uid + sender_idx_str);
+      auto sender_conn_obj = obj_fac.create("SocketDetectorToDaqConnection", sender_conn_uid);
+      sender_conn_obj.set_objs("net_senders", { &sender->config_object() });
+      sender_conn_obj.set_obj("net_receiver", &receiver->config_object());
+      const auto* sender_conn = obj_fac.get_dal<appmodel::SocketDetectorToDaqConnection>(sender_conn_obj.UID());
+      const auto* sender_conn_conf_obj = &sender_conn->config_object();
 
-    //std::string reader_uid(fmt::format("crtframebuilder-{}-{}", this->UID(), std::to_string(conn_idx++)));
-    //TLOG_DEBUG(6) << fmt::format("creating OKS configuration object for Data reader class {} with id {}", reader_class, reader_uid);
-    //auto reader_obj = obj_fac.create(reader_class, reader_uid);
-//
-    //// Populate configuration and interfaces
-    //reader_obj.set_obj("configuration", &reader_conf->config_object());
-    //reader_obj.set_objs("connections", { &d2d_conn->config_object() });
-    //reader_obj.set_objs("raw_data_callbacks", raw_data_callback_objs);
-//
-    //modules.push_back(obj_fac.get_dal<confmodel::DaqModule>(reader_obj.UID()));
+      // Create data queue
+      conffwk::ConfigObject queue_obj = obj_fac.create_queue_obj(crtframebuilder_output_qdesc, sender_idx_str);
+      const auto* queue = obj_fac.get_dal<confmodel::Connection>(queue_obj.UID());
+      const auto* queue_conf_obj = &queue->config_object();
 
-    //-----------------------------------------------------------------
-    //
-    // Create DataWriterModule object
-    //
+      //-----------------------------------------------------------------
+      //
+      // Create DetectorFrameBuilderModule object
+      //
+  
+      //
+      // Instantiate DetectorFrameBuilderModule of type CRTBernFrameBuilderModule/CRTGrenobleFrameBuilderModule
+      //
+  
+      // Create the detector frame builder object
+  
+      std::string builder_uid(fmt::format("crt-frame-builder-{}-{}", this->UID(), sender_idx_str));
+      TLOG_DEBUG(6) << fmt::format("creating OKS configuration object for detector frame builder class {} with id {}", builder_class, builder_uid);
+      auto builder_obj = obj_fac.create(builder_class, builder_uid);
+  
+      // Populate configuration and interfaces
+      builder_obj.set_obj("configuration", &det_frame_builder_conf->config_object());
+      builder_obj.set_obj("connection", sender_conn_conf_obj);
+      builder_obj.set_objs("outputs", { queue_conf_obj });
+  
+      modules.push_back(obj_fac.get_dal<confmodel::DaqModule>(builder_obj.UID()));
 
-    //
-    // Instantiate DataWriterModule of type SocketWriterModule
-    //
+      //-----------------------------------------------------------------
+      //
+      // Create DataWriterModule object
+      //
+  
+      //
+      // Instantiate DataWriterModule of type SocketWriterModule
+      //
+  
+      // Create the SocketWriterModule object
+  
+      std::string writer_uid(fmt::format("socket-writer-{}-{}", this->UID(), sender_idx_str));
+      TLOG_DEBUG(6) << fmt::format("Creating OKS configuration object for socket writer class {} with id {}", writer_class, writer_uid);
+      auto writer_obj = obj_fac.create(writer_class, writer_uid);
+  
+      // Populate configuration and interfaces
+      writer_obj.set_obj("configuration", &writer_conf->config_object());
+      writer_obj.set_obj("connection", sender_conn_conf_obj);
+      writer_obj.set_objs("inputs", { queue_conf_obj });
+  
+      modules.push_back(obj_fac.get_dal<confmodel::DaqModule>(writer_obj.UID()));    
 
-    // Create the SocketWriterModule object
-
-    std::string writer_uid(fmt::format("socketwriter-{}-{}", this->UID(), std::to_string(conn_idx++)));
-    TLOG_DEBUG(6) << fmt::format("Creating OKS configuration object for socket writer class {} with id {}", writer_class, writer_uid);
-    auto writer_obj = obj_fac.create(writer_class, writer_uid);
-
-    // Populate configuration and interfaces
-    writer_obj.set_obj("configuration", &writer_conf->config_object());
-    writer_obj.set_objs("connections", {&d2d_conn->config_object()});
-    writer_obj.set_objs("raw_data_callbacks", raw_data_callback_objs);
-
-    modules.push_back(obj_fac.get_dal<confmodel::DaqModule>(writer_obj.UID()));    
+      ++sender_idx;
+    }
   }
 
   obj_fac.update_modules(modules);

--- a/src/CRTReaderApplication.cpp
+++ b/src/CRTReaderApplication.cpp
@@ -31,6 +31,7 @@
 
 #include <string>
 #include <vector>
+#include <memory>
 
 namespace dunedaq::appmodel {
 
@@ -55,14 +56,14 @@ void
 
   // Data reader  
   const auto reader_conf = get_data_reader();
-  if (reader_conf == 0) {
+  if (reader_conf == nullptr) {
     throw(BadConf(ERS_HERE, "No DataReaderModule configuration given"));
   }  
   const std::string reader_class = reader_conf->get_template_for();
   
   // Data writer  
   const auto writer_conf = get_data_writer();
-  if (writer_conf == 0) {
+  if (writer_conf == nullptr) {
     throw(BadConf(ERS_HERE, "No DataWriterModule configuration given"));
   }    
   const std::string writer_class = writer_conf->get_template_for();
@@ -84,7 +85,7 @@ void
   // - One data reader per detector connection
   // - One data writer per detector connection
 
-  uint16_t conn_idx = 0;
+  uint16_t conn_idx = 0; // NOLINT(build/unsigned)
 
   for (auto d2d_conn : get_detector_connections()) {
 

--- a/src/CRTReaderApplication.cpp
+++ b/src/CRTReaderApplication.cpp
@@ -56,44 +56,33 @@ CRTReaderApplication::generate_modules(const confmodel::Session* session) const
   const auto reader_conf = get_data_reader();
   if (reader_conf == 0) {
     throw(BadConf(ERS_HERE, "No DataReaderModule configuration given"));
-  }
+  }  
   const std::string reader_class = reader_conf->get_template_for();
   
-  // Data writers    
-  const auto writer_confs = get_data_writers();
-  if (writer_confs.size() == 0) {
+  // Data writer  
+  const auto writer_conf = get_data_writer();
+  if (writer_conf == 0) {
     throw(BadConf(ERS_HERE, "No DataWriterModule configuration given"));
   }    
-  
-  //
-  // Process the queue rules looking for inputs to our DL/TP handler modules
-  //
-  const QueueDescriptor* dlh_input_qdesc = nullptr;
+  const std::string writer_class = writer_conf->get_template_for();
 
-  for (auto rule : get_queue_rules()) {
-    auto destination_class = rule->get_destination_class();
-    auto data_type = rule->get_descriptor()->get_data_type();
-    // Why datahander here? It is the base class for several DataHandler types (e.g. FDDataHandlerModule,
-    // SNBDataHandlerModule)
-    if (destination_class == "DataHandlerModule") {
-      if (data_type != "DataRequest") {
-        dlh_input_qdesc = rule->get_descriptor();
-      }
-    }
+  //
+  // Process the queue rules looking for inputs to our socket writer modules
+  //
+  const QueueDescriptor* crtreader_output_qdesc = nullptr;
+  auto queue_rules = get_queue_rules();
+  if (queue_rules.size() != 1) {
+    throw(BadConf(ERS_HERE, "Strictly 1 queue rule is expected"));
   }
-
-  if (dlh_input_qdesc == nullptr) {
-    throw(BadConf(ERS_HERE, "No data link handler input queue descriptor given"));
-  }
+  crtreader_output_qdesc = queue_rules[0]->get_descriptor();
 
   //
   // Scan Detector 2 DAQ connections to extract sender, receiver and stream information
   //
 
-  // Loop over the detector to daq connections and generate one data reader per connection
-
-  // Collect all streams
-  std::map<uint32_t, const confmodel::Connection*> data_queues_by_sid;
+  // Loop over the detector to daq connections and generate:
+  // - One data reader per detector connection
+  // - One data writer per detector connection
 
   uint16_t conn_idx = 0;
 
@@ -106,9 +95,8 @@ CRTReaderApplication::generate_modules(const confmodel::Session* session) const
     }
 
     TLOG_DEBUG(6) << "Processing DetectorToDaqConnection " << d2d_conn->UID();
-    // get the readout groups and the interfaces and streams therein; 1 reaout group corresponds to 1 data reader module      
-
-    std::vector<const confmodel::DetectorStream*> enabled_det_streams;      
+    
+    std::vector<const confmodel::DetectorStream*> enabled_det_streams;
     // Loop over streams
     for (auto stream : d2d_conn->streams()) {
 
@@ -123,15 +111,13 @@ CRTReaderApplication::generate_modules(const confmodel::Session* session) const
 
     // Create the raw data queues
     std::vector<const conffwk::ConfigObject*> data_queue_objs;
-    // keep a map for convenience
 
     // Create data queues
     for (auto ds : enabled_det_streams) {
-      conffwk::ConfigObject queue_obj = obj_fac.create_queue_sid_obj(dlh_input_qdesc, ds);
+      conffwk::ConfigObject queue_obj = obj_fac.create_queue_sid_obj(crtreader_output_qdesc, ds);
       const auto* data_queue = obj_fac.get_dal<confmodel::Connection>(queue_obj.UID());
       data_queue_objs.push_back(&data_queue->config_object());
-      data_queues_by_sid[ds->get_source_id()] = data_queue;
-    }
+    }    
         
     //-----------------------------------------------------------------
     //
@@ -144,11 +130,11 @@ CRTReaderApplication::generate_modules(const confmodel::Session* session) const
 
     // Create the Data reader object
 
-    std::string reader_uid(fmt::format("crtdatareader-{}-{}", this->UID(), std::to_string(conn_idx++)));
+    std::string reader_uid(fmt::format("crtreader-{}-{}", this->UID(), std::to_string(conn_idx++)));
     TLOG_DEBUG(6) << fmt::format("creating OKS configuration object for Data reader class {} with id {}", reader_class, reader_uid);
     auto reader_obj = obj_fac.create(reader_class, reader_uid);
 
-    // Populate configuration and interfaces (leave output queues for later)
+    // Populate configuration and interfaces
     reader_obj.set_obj("configuration", &reader_conf->config_object());
     reader_obj.set_objs("connections", {&d2d_conn->config_object()});
     reader_obj.set_objs("outputs", data_queue_objs);
@@ -157,33 +143,25 @@ CRTReaderApplication::generate_modules(const confmodel::Session* session) const
 
     //-----------------------------------------------------------------
     //
-    // Create DataWriterModule objects
+    // Create DataWriterModule object
     //
 
     //
     // Instantiate DataWriterModule of type SocketWriterModule
     //
 
-    // Create the SocketWriterModule objects
+    // Create the SocketWriterModule object
 
-    conn_idx = 0;
-    
-    for (const auto writer_conf : writer_confs) {
+    std::string writer_uid(fmt::format("socketwriter-{}-{}", this->UID(), std::to_string(conn_idx++)));
+    TLOG_DEBUG(6) << fmt::format("Creating OKS configuration object for socket writer class {} with id {}", writer_class, writer_uid);
+    auto writer_obj = obj_fac.create(writer_class, writer_uid);
 
-      const std::string writer_class = writer_conf->get_template_for();
+    // Populate configuration and interfaces
+    writer_obj.set_obj("configuration", &writer_conf->config_object());
+    writer_obj.set_objs("connections", {&d2d_conn->config_object()});
+    writer_obj.set_objs("inputs", data_queue_objs);
 
-      std::string writer_uid(fmt::format("socketdatawriter-{}-{}", this->UID(), std::to_string(conn_idx++)));
-      TLOG_DEBUG(6) << fmt::format(
-        "Creating OKS configuration object for socket data writer class {} with id {}", writer_class, writer_uid);
-      auto writer_obj = obj_fac.create(writer_class, writer_uid);
-
-      // Populate configuration and interfaces
-      writer_obj.set_obj("configuration", &writer_conf->config_object());
-      writer_obj.set_objs("connections", {&d2d_conn->config_object()});
-      writer_obj.set_objs("inputs", data_queue_objs);
-
-      modules.push_back(obj_fac.get_dal<confmodel::DaqModule>(writer_obj.UID()));
-    }
+    modules.push_back(obj_fac.get_dal<confmodel::DaqModule>(writer_obj.UID()));    
   }
 
   obj_fac.update_modules(modules);

--- a/src/CRTReaderApplication.cpp
+++ b/src/CRTReaderApplication.cpp
@@ -68,14 +68,13 @@ CRTReaderApplication::generate_modules(const confmodel::Session* session) const
   const std::string writer_class = writer_conf->get_template_for();
 
   //
-  // Process the queue rules looking for inputs to our socket writer modules
+  // Get the callback descriptor
   //
-  const QueueDescriptor* crtreader_output_qdesc = nullptr;
-  auto queue_rules = get_queue_rules();
-  if (queue_rules.size() != 1) {
-    throw(BadConf(ERS_HERE, "Strictly 1 queue rule is expected"));
+  const DataMoveCallbackDescriptor* raw_data_callback_desc = get_callback_desc();
+
+  if (raw_data_callback_desc == nullptr) {
+    throw(BadConf(ERS_HERE, "No Raw Data Callback descriptor given"));
   }
-  crtreader_output_qdesc = queue_rules[0]->get_descriptor();
 
   //
   // Scan Detector 2 DAQ connections to extract sender, receiver and stream information
@@ -110,15 +109,15 @@ CRTReaderApplication::generate_modules(const confmodel::Session* session) const
       enabled_det_streams.push_back(stream);
     }
 
-    // Create the raw data queues
-    std::vector<const conffwk::ConfigObject*> data_queue_objs;
+    // Create the raw data callbacks
+    std::vector<const conffwk::ConfigObject*> raw_data_callback_objs;
 
     // Create data queues
     for (auto ds : enabled_det_streams) {
-      conffwk::ConfigObject queue_obj = obj_fac.create_queue_sid_obj(crtreader_output_qdesc, ds);
-      const auto* data_queue = obj_fac.get_dal<confmodel::Connection>(queue_obj.UID());
-      data_queue_objs.push_back(&data_queue->config_object());
-    }    
+      conffwk::ConfigObject callback_obj = obj_fac.create_callback_sid_obj(raw_data_callback_desc, ds->get_source_id());
+      const auto* callback_conf = obj_fac.get_dal<DataMoveCallbackConf>(callback_obj.UID());
+      raw_data_callback_objs.push_back(&callback_conf->config_object());
+    }  
         
     //-----------------------------------------------------------------
     //
@@ -138,7 +137,7 @@ CRTReaderApplication::generate_modules(const confmodel::Session* session) const
     // Populate configuration and interfaces
     reader_obj.set_obj("configuration", &reader_conf->config_object());
     reader_obj.set_objs("connections", { &d2d_conn->config_object() });
-    reader_obj.set_objs("outputs", data_queue_objs);
+    reader_obj.set_objs("raw_data_callbacks", raw_data_callback_objs);
 
     modules.push_back(obj_fac.get_dal<confmodel::DaqModule>(reader_obj.UID()));
 
@@ -160,7 +159,7 @@ CRTReaderApplication::generate_modules(const confmodel::Session* session) const
     // Populate configuration and interfaces
     writer_obj.set_obj("configuration", &writer_conf->config_object());
     writer_obj.set_objs("connections", {&d2d_conn->config_object()});
-    writer_obj.set_objs("inputs", data_queue_objs);
+    writer_obj.set_objs("raw_data_callbacks", raw_data_callback_objs);
 
     modules.push_back(obj_fac.get_dal<confmodel::DaqModule>(writer_obj.UID()));    
   }

--- a/src/CRTReaderApplication.cpp
+++ b/src/CRTReaderApplication.cpp
@@ -138,7 +138,7 @@ CRTReaderApplication::generate_modules(const confmodel::Session* session) const
     // Populate configuration and interfaces
     reader_obj.set_obj("configuration", &reader_conf->config_object());
     reader_obj.set_objs("connections", { &d2d_conn->config_object() });
-    reader_obj.set_objs("raw_data_callbacks", raw_data_callback_objs);
+    reader_obj.set_objs("outputs", data_queue_objs);
 
     modules.push_back(obj_fac.get_dal<confmodel::DaqModule>(reader_obj.UID()));
 

--- a/src/ConfigurationHelper.cpp
+++ b/src/ConfigurationHelper.cpp
@@ -124,7 +124,12 @@ ConfigurationHelper::get_tp_source_ids(){
   for (auto app: m_session->enabled_applications()) {
     auto ro_app = app->cast<appmodel::ReadoutApplication>();
     if (ro_app != nullptr) {
-      result.insert(std::pair(app->UID(), ro_app->get_tp_source_ids()));
+      if (ro_app->get_tp_generation_enabled()) {
+        result.insert(std::pair(app->UID(), ro_app->get_tp_source_ids()));
+      }
+      else {
+        result.insert({app->UID(), std::vector<const SourceIDConf*>()});
+      }
     }
     auto replay_app = app->cast<appmodel::TPReplayApplication>();
     if (replay_app != nullptr) {

--- a/src/ReadoutApplication.cpp
+++ b/src/ReadoutApplication.cpp
@@ -233,13 +233,20 @@ ReadoutApplication::generate_modules(const confmodel::Session* session) const
 
     // Here I want to resolve the type of connection (network, felix, or?)
     // Rules of engagement: if the receiver interface is network or felix, the receivers should be castable to the counterpart
-    if (reader_class == "DPDKReaderModule" || reader_class == "SocketReaderModule") {
+    if (reader_class == "DPDKReaderModule") {
       if (!d2d_conn->castable("NetworkDetectorToDaqConnection")) {
         throw(BadConf(ERS_HERE, fmt::format("{} requires NetworkDetectorToDaqConnection, found {} of class {}", reader_class, d2d_conn->UID(), d2d_conn->class_name())));
       }
-      if ((reader_class == "DPDKReaderModule" && !det_receiver->cast<appmodel::DPDKReceiver>()) ||
-          (reader_class == "SocketReaderModule" && !det_receiver->cast<appmodel::SocketReceiver>())) {
+      if (!det_receiver->cast<appmodel::DPDKReceiver>()) {
         throw(BadConf(ERS_HERE, fmt::format("{} requires NWDetDataReceiver, found {} of class {}", reader_class, det_receiver->UID(), det_receiver->class_name())));
+      }
+    }
+    else if (reader_class == "SocketReaderModule") {
+      if (!d2d_conn->castable("SocketDetectorToDaqConnection")) {
+        throw(BadConf(ERS_HERE, fmt::format("{} requires SocketDetectorToDaqConnection, found {} of class {}", reader_class, d2d_conn->UID(), d2d_conn->class_name())));
+      }   
+      if (!det_receiver->cast<appmodel::SocketReceiver>()) {
+        throw(BadConf(ERS_HERE, fmt::format("{} requires SocketReceiver, found {} of class {}", reader_class, det_receiver->UID(), det_receiver->class_name())));
       }
     }
     else if (reader_class == "FelixReaderModule") {

--- a/test/apps/generate_modules_test.cxx
+++ b/test/apps/generate_modules_test.cxx
@@ -118,16 +118,6 @@ main(int argc, char* argv[])
         }
       }
 
-      auto socketwriter_module = daq_module->cast<appmodel::SocketDataWriterModule>();
-      if (socketwriter_module != nullptr) {
-        auto callback_confs = socketwriter_module->get_raw_data_callbacks();
-        std::cout << " callback confs " << std::endl;
-        for (auto* callback_conf : callback_confs) {
-          auto cbObj = callback_conf->config_object();
-          cbObj.print_ref(std::cout, *confdb, "    ");
-        }
-      }
-
       std::cout << std::endl;
     }
   } else {

--- a/test/apps/generate_modules_test.cxx
+++ b/test/apps/generate_modules_test.cxx
@@ -27,8 +27,9 @@
 
 #include "appmodel/DataHandlerModule.hpp"
 #include "appmodel/DataReaderModule.hpp"
+#include "appmodel/CRTBernReaderModule.hpp"
+#include "appmodel/CRTGrenobleReaderModule.hpp"
 #include "appmodel/DataMoveCallbackConf.hpp"
-#include "appmodel/SocketDataWriterModule.hpp"
 
 #include "appmodel/appmodelIssues.hpp"
 
@@ -97,26 +98,21 @@ main(int argc, char* argv[])
 
       auto reader_module = daq_module->cast<appmodel::DataReaderModule>();
       if (reader_module != nullptr) {
-        auto callback_confs = reader_module->get_raw_data_callbacks();
-        std::cout << " callback confs " << std::endl;
-        for (auto* callback_conf : callback_confs) {
-          auto cbObj = callback_conf->config_object();
-          cbObj.print_ref(std::cout, *confdb, "    ");
+        auto crt_reader_module = daq_module->cast<dunedaq::appmodel::CRTBernReaderModule>() != nullptr ||
+                                 daq_module->cast<dunedaq::appmodel::CRTGrenobleReaderModule>() != nullptr;
+        if (!crt_reader_module) { // Don't check raw data callbacks for CRT readers
+          auto callback_confs = reader_module->get_raw_data_callbacks();
+          std::cout << " callback confs " << std::endl;
+          for (auto* callback_conf : callback_confs) {
+            auto cbObj = callback_conf->config_object();
+            cbObj.print_ref(std::cout, *confdb, "    ");
+          }
         }
       }
 
       auto handler_module = daq_module->cast<appmodel::DataHandlerModule>();
       if (handler_module != nullptr) {
         auto callback_conf = handler_module->get_raw_data_callback();
-        if (callback_conf != nullptr) {
-          auto cbObj = callback_conf->config_object();
-          cbObj.print_ref(std::cout, *confdb, "    ");
-        }
-      }
-
-      auto socketwriter_module = daq_module->cast<appmodel::SocketDataWriterModule>();
-      if (socketwriter_module != nullptr) {
-        auto callback_conf = socketwriter_module->get_raw_data_callback();
         if (callback_conf != nullptr) {
           auto cbObj = callback_conf->config_object();
           cbObj.print_ref(std::cout, *confdb, "    ");

--- a/test/apps/generate_modules_test.cxx
+++ b/test/apps/generate_modules_test.cxx
@@ -27,9 +27,8 @@
 
 #include "appmodel/DataHandlerModule.hpp"
 #include "appmodel/DataReaderModule.hpp"
-#include "appmodel/CRTBernReaderModule.hpp"
-#include "appmodel/CRTGrenobleReaderModule.hpp"
 #include "appmodel/DataMoveCallbackConf.hpp"
+#include "appmodel/SocketDataWriterModule.hpp"
 
 #include "appmodel/appmodelIssues.hpp"
 
@@ -98,15 +97,11 @@ main(int argc, char* argv[])
 
       auto reader_module = daq_module->cast<appmodel::DataReaderModule>();
       if (reader_module != nullptr) {
-        auto crt_reader_module = daq_module->cast<dunedaq::appmodel::CRTBernReaderModule>() != nullptr ||
-                                 daq_module->cast<dunedaq::appmodel::CRTGrenobleReaderModule>() != nullptr;
-        if (!crt_reader_module) { // Don't check raw data callbacks for CRT readers
-          auto callback_confs = reader_module->get_raw_data_callbacks();
-          std::cout << " callback confs " << std::endl;
-          for (auto* callback_conf : callback_confs) {
-            auto cbObj = callback_conf->config_object();
-            cbObj.print_ref(std::cout, *confdb, "    ");
-          }
+        auto callback_confs = reader_module->get_raw_data_callbacks();
+        std::cout << " callback confs " << std::endl;
+        for (auto* callback_conf : callback_confs) {
+          auto cbObj = callback_conf->config_object();
+          cbObj.print_ref(std::cout, *confdb, "    ");
         }
       }
 
@@ -114,6 +109,16 @@ main(int argc, char* argv[])
       if (handler_module != nullptr) {
         auto callback_conf = handler_module->get_raw_data_callback();
         if (callback_conf != nullptr) {
+          auto cbObj = callback_conf->config_object();
+          cbObj.print_ref(std::cout, *confdb, "    ");
+        }
+      }
+
+      auto socketwriter_module = daq_module->cast<appmodel::SocketDataWriterModule>();
+      if (socketwriter_module != nullptr) {
+        auto callback_confs = socketwriter_module->get_raw_data_callbacks();
+        std::cout << " callback confs " << std::endl;
+        for (auto* callback_conf : callback_confs) {
           auto cbObj = callback_conf->config_object();
           cbObj.print_ref(std::cout, *confdb, "    ");
         }


### PR DESCRIPTION
### 20.03 Updates:
CRTReader **is not** a `DataReader`. It's not an interface to read DAQ frames from a front-end (like `DPDKReader`) and send them to data handlers. Instead, it **builds DAQ frames** from raw electronics output. It's similar to Hermes FW, a functional block that prepares data and passes it on.
The new name, `CRTFrameBuilder`, eliminates confusion with standard `DataReader` modules and accurately reflects its role as a builder of DAQ frames rather than a reader.

- CRT frame builders communicate with SocketWriter via IOM.
- For each connection, there are, per DataSender:
  - 1 dedicated D2D connection (with this sender only)
  - 1 CRT frame builder
  - 1 SocketWriter
  - 1 IOM

---
[appmodel PR](https://github.com/DUNE-DAQ/appmodel/pull/278) dte/crt_topology_change
[daqsystemtest PR](https://github.com/DUNE-DAQ/daqsystemtest/pull/303) dte/crt_topology_change
[crtmodules PR](https://github.com/DUNE-DAQ/crtmodules/pull/32) dte/crt_topology_change
[asiolibs PR](https://github.com/DUNE-DAQ/asiolibs/pull/37) dte/crt_topology_change
[daqconf PR](https://github.com/DUNE-DAQ/daqconf/pull/622) dte/crt_cb_update
[datahandlinglibs PR](https://github.com/DUNE-DAQ/datahandlinglibs/pull/130) dte/cb_acquire
[fdreadoutmodules PR](https://github.com/DUNE-DAQ/fdreadoutmodules/pull/64) dte/crt_rates

Prior to this development, socket connection info resided in reader and writer configurations. Now, there is SocketDetectorToDaqConnection which has SocketDataSenders and SocketReceiver; SocketDataSender has the info socket type (TCP/UDP), local port and remote port; plus we make use of their NetworkInterface.ip_address to interpret them as local IP and remote IP.

CRT readers communicate with socket writers via IOM.
Socket readers communicate with DHLs via callbacks.

To try out:
- `drunc-unified-shell ssh-standalone config/daqsystemtest/example-configs.data.xml local-socket-1x1-config ${USER}-local-test`
- `generate_modules_test local-socket-1x1-config crt-data-source-01 config/daqsystemtest/example-configs.data.xml`
- `generate_modules_test local-socket-1x1-config socket-ru-01 config/daqsystemtest/example-configs.data.xml`

---

## Type of change

- [x] New feature or enhancement (non-breaking change which adds functionality)

## Testing checklist

- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [x] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)

