### PR TITLE
Don't add tp_src_ids for ro apps with tp_generation disabled

### DIFF
--- a/src/ConfigurationHelper.cpp
+++ b/src/ConfigurationHelper.cpp
@@ -124,7 +124,12 @@ ConfigurationHelper::get_tp_source_ids(){
   for (auto app: m_session->enabled_applications()) {
     auto ro_app = app->cast<appmodel::ReadoutApplication>();
     if (ro_app != nullptr) {
-      result.insert(std::pair(app->UID(), ro_app->get_tp_source_ids()));
+      if (ro_app->get_tp_generation_enabled()) {
+        result.insert(std::pair(app->UID(), ro_app->get_tp_source_ids()));
+      }
+      else {
+        result.insert({app->UID(), std::vector<const SourceIDConf*>()});
+      }
     }
     auto replay_app = app->cast<appmodel::TPReplayApplication>();
     if (replay_app != nullptr) {


### PR DESCRIPTION
# Description

Disabling tp generation in ReadoutApplication results in requests for tps to an unknown sender. This is because the MLT was getting a list of tp source ids for the ReadoutApplication. This patch adds a check to the `ConfigurationHelper::get_tp_source_ids` method to set an empty vector for ReadoutApplications with tp_generation_enabled set to false.


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

