### PR TITLE
Prep release/fddaq v5.6.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(appmodel VERSION 5.0.0)
+project(appmodel VERSION 5.0.1)
 
 find_package(daq-cmake REQUIRED)
 

--- a/src/ConfigurationHelper.cpp
+++ b/src/ConfigurationHelper.cpp
@@ -124,7 +124,12 @@ ConfigurationHelper::get_tp_source_ids(){
   for (auto app: m_session->enabled_applications()) {
     auto ro_app = app->cast<appmodel::ReadoutApplication>();
     if (ro_app != nullptr) {
-      result.insert(std::pair(app->UID(), ro_app->get_tp_source_ids()));
+      if (ro_app->get_tp_generation_enabled()) {
+        result.insert(std::pair(app->UID(), ro_app->get_tp_source_ids()));
+      }
+      else {
+        result.insert({app->UID(), std::vector<const SourceIDConf*>()});
+      }
     }
     auto replay_app = app->cast<appmodel::TPReplayApplication>();
     if (replay_app != nullptr) {


### PR DESCRIPTION
# Description

This fixes a but in the configuration helper that exposed the TP source IDs even when the TP generation was disabled. 

To test, just run a configuration without TPG and with TP source IDs associated to the readout application. The requests will be correct. Without this fix, the system will not be able to complete TRs.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

