### PR TITLE
NUMA allocation with NP02ReadoutApplication and fake readers

### DIFF
--- a/src/NP02ReadoutApplication.cpp
+++ b/src/NP02ReadoutApplication.cpp
@@ -208,18 +208,24 @@ NP02ReadoutApplication::generate_modules(std::shared_ptr<appmodel::Configuration
     auto det_senders = d2d_conn->senders();
     auto det_receiver = d2d_conn->receiver();
 
+    TLOG() << "reader class: " << reader_class;
+    TLOG() << "Receiver: " << det_receiver->class_name();
 
     // Here I want to resolve the type of connection (network, felix, or?)
     // Rules of engagement: if the receiver interface is network or felix, the receivers should be castable to the counterpart
-    if (reader_class == "DPDKReaderModule" || reader_class == "SocketReaderModule") {
+    if (reader_class == "DPDKReaderModule" || reader_class == "SocketReaderModule" || reader_class == "FDFakeReaderModule") {
       if ((reader_class == "DPDKReaderModule" && !det_receiver->cast<appmodel::DPDKReceiver>()) ||
+          (reader_class == "FDFakeReaderModule" && !det_receiver->cast<appmodel::DPDKReceiver>()) || // SSB: Note here, we are intrinsically locking FakeCard readout to only emulate DPDK data reception. Given NP02ReadoutApplication is intended for TDE readout at NP02, assuming this is OK.
           (reader_class == "SocketReaderModule" && !det_receiver->cast<appmodel::SocketReceiver>())) {
         throw(BadConf(ERS_HERE, fmt::format("{} requires NWDetDataReceiver, found {} of class {}", reader_class, det_receiver->UID(), det_receiver->class_name())));
       }
 
-      if (reader_class == "DPDKReaderModule") {
+      // SSB: Note that here you need to include FDFakeCardReader as well, because emulated readout needs some way to map NUMA to streams
+      // Since we require a receiver in the NetworkDetector2DAQConnections this would still work if the receiver type is a DPDKReceiver
+      if (reader_class == "DPDKReaderModule" || reader_class == "FDFakeReaderModule") {
         auto dpdk_reciever = det_receiver->cast<appmodel::DPDKReceiver>();
         receiver_numa = (int16_t)dpdk_reciever->get_uses()->get_numa_id();
+        TLOG() << "receiver numa: " << receiver_numa;
       }
 
       bool all_nw_senders = true;

--- a/src/NP02ReadoutApplication.cpp
+++ b/src/NP02ReadoutApplication.cpp
@@ -208,9 +208,6 @@ NP02ReadoutApplication::generate_modules(std::shared_ptr<appmodel::Configuration
     auto det_senders = d2d_conn->senders();
     auto det_receiver = d2d_conn->receiver();
 
-    TLOG() << "reader class: " << reader_class;
-    TLOG() << "Receiver: " << det_receiver->class_name();
-
     // Here I want to resolve the type of connection (network, felix, or?)
     // Rules of engagement: if the receiver interface is network or felix, the receivers should be castable to the counterpart
     if (reader_class == "DPDKReaderModule" || reader_class == "SocketReaderModule" || reader_class == "FDFakeReaderModule") {


### PR DESCRIPTION
# Description

_If full description and testing details are included on a parent issue, please link to that here._
See issue # for details

_Otherwise, please include a summary of the change and which issue is fixed (if any).
Include relevant motivation and context, including a target environment and dunedaq version if known.
Also list any dependencies that are required for this change._

Allow using NUMA allocation through the dpdk receivers when FDFakeReaderModules are used. Without this, latency buffers are assigned numa 0 by default and cant be changed, so this limits the scope of using the NP02 readout application on servers where typically we need to assign the latency buffers to two NUMA regions.

Can be tested by running
```
daqconf_inspector sessions/np02-emu-session.data.xml show-smartapp-mods np02-emu-session runp02srv004-crp23-emu
```
and searching the output for the assigned NUMA node for the latency buffers in each daq application. it should be assigned to 2 and 3 when using the following ehn1-daqconfigs branch (parallel PR):
https://gitlab.cern.ch/dune-daq/online/ehn1-daqconfigs/-/merge_requests/274

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

unit test and integration tests should pass.

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

