### PR TITLE
 Delayed postprocessing attribute name changes

### DIFF
--- a/schema/appmodel/application.schema.xml
+++ b/schema/appmodel/application.schema.xml
@@ -153,8 +153,8 @@
   <attribute name="input_data_type" description="Type of data received by this readout module" type="string" init-value="WIBEthFrame"/>
   <attribute name="generate_timesync" type="bool" init-value="true" is-not-null="yes"/>
   <attribute name="post_processing_delay_ticks" description="Number of clock tick by which post processing of incoming data shall be delayed." type="u64" init-value="0" is-not-null="yes"/>
-  <attribute name="post_processing_delay_min_wait" description="Minimum time (ms) between consecutive post processing operations." type="u64" init-value="1" is-not-null="yes"/>
-  <attribute name="post_processing_delay_max_wait" description="Maximum wait time (ms) before post processing check if no new data arrives." type="u64" init-value="5" is-not-null="yes"/>
+  <attribute name="post_processing_delay_min_wait_ms" description="Minimum time (ms) between consecutive post processing operations." type="u64" init-value="1" is-not-null="yes"/>
+  <attribute name="post_processing_delay_max_wait_ms" description="Maximum wait time (ms) before post processing check if no new data arrives." type="u64" init-value="5" is-not-null="yes"/>
   <relationship name="request_handler" class-type="RequestHandler" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <relationship name="latency_buffer" class-type="LatencyBuffer" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <relationship name="data_processor" class-type="DataProcessor" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>

--- a/schema/appmodel/application.schema.xml
+++ b/schema/appmodel/application.schema.xml
@@ -80,7 +80,7 @@
 
 <oks-schema>
 
-<info name="" type="" num-of-items="72" oks-format="schema" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20230616T091343" last-modified-by="dergonul" last-modified-on="np04-srv-015.cern.ch" last-modification-time="20260319T161203"/>
+<info name="" type="" num-of-items="72" oks-format="schema" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20230616T091343" last-modified-by="dergonul" last-modified-on="np04-srv-029.cern.ch" last-modification-time="20260407T091232"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
@@ -155,6 +155,7 @@
   <attribute name="post_processing_delay_ticks" description="Number of clock tick by which post processing of incoming data shall be delayed." type="u64" init-value="0" is-not-null="yes"/>
   <attribute name="post_processing_delay_min_wait_ms" description="Minimum time (ms) between consecutive post processing operations." type="u64" init-value="1" is-not-null="yes"/>
   <attribute name="post_processing_delay_max_wait_ms" description="Maximum wait time (ms) before post processing check if no new data arrives." type="u64" init-value="5" is-not-null="yes"/>
+  <attribute name="post_processing_delay_monitor_late_tick_diffs_only" description="Toggle between monitoring late arrivals only versus all arrivals" type="bool" init-value="true" is-not-null="yes"/>
   <relationship name="request_handler" class-type="RequestHandler" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <relationship name="latency_buffer" class-type="LatencyBuffer" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <relationship name="data_processor" class-type="DataProcessor" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
@@ -169,6 +170,16 @@
   <relationship name="geo_id" class-type="GeoId" low-cc="zero" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <relationship name="raw_data_callback" description="Configuration for raw data callback" class-type="DataMoveCallbackConf" low-cc="zero" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
   <relationship name="module_configuration" class-type="DataHandlerConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
+ </class>
+
+ <class name="DataMoveCallbackConf">
+  <attribute name="source_id" type="u32" init-value="0" is-not-null="yes"/>
+  <attribute name="data_type" description="Name of the output data type. Should be defined via a call to DUNE_DAQ_TYPESTRING" type="string" init-value="WIBEthFrame"/>
+ </class>
+
+ <class name="DataMoveCallbackDescriptor">
+  <attribute name="uid_base" description="Base for callback UID string. May be combined with a source id" type="string" is-not-null="yes"/>
+  <attribute name="data_type" description="string identifying type of data passed as a callback parameter" type="string" is-not-null="yes"/>
  </class>
 
  <class name="DataProcessor">
@@ -190,16 +201,6 @@
   <relationship name="connections" class-type="DetectorToDaqConnection" low-cc="one" high-cc="many" is-composite="yes" is-exclusive="no" is-dependent="no"/>
   <relationship name="raw_data_callbacks" description="Configurations for raw data callbacks" class-type="DataMoveCallbackConf" low-cc="one" high-cc="many" is-composite="no" is-exclusive="no" is-dependent="no"/>
  </class>
-
- <class name="DetectorFrameBuilderConf">
-  <attribute name="template_for" description="OKS class of the DetectorFrameBuilderModule that this config is a template for" type="class" init-value="DetectorFrameBuilderModule" is-not-null="yes"/>
- </class>
-
- <class name="DetectorFrameBuilderModule" is-abstract="yes">
-  <superclass name="DaqModule"/>
-  <relationship name="configuration" class-type="DetectorFrameBuilderConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
-  <relationship name="connection" class-type="DetectorToDaqConnection" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
- </class> 
 
  <class name="DataRecorderConf">
   <attribute name="output_file" type="string"/>
@@ -237,6 +238,16 @@
   <superclass name="DaqModule"/>
   <attribute name="writer_identifier" type="string"/>
   <relationship name="configuration" class-type="DataWriterConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
+ </class>
+
+ <class name="DetectorFrameBuilderConf">
+  <attribute name="template_for" description="OKS class of the DetectorFrameBuilderModule that this config is a template for" type="class" init-value="DetectorFrameBuilderModule" is-not-null="yes"/>
+ </class>
+
+ <class name="DetectorFrameBuilderModule" is-abstract="yes">
+  <superclass name="DaqModule"/>
+  <relationship name="configuration" class-type="DetectorFrameBuilderConf" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
+  <relationship name="connection" class-type="DetectorToDaqConnection" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
  </class>
 
  <class name="FakeDataApplication">
@@ -413,16 +424,6 @@
   <attribute name="queue_type" description="Type of queue" type="enum" range="kUnknown,kStdDeQueue,kFollySPSCQueue,kFollyMPMCQueue" init-value="kFollySPSCQueue" is-not-null="yes"/>
   <attribute name="capacity" type="u32" init-value="100" is-not-null="yes"/>
   <attribute name="data_type" description="string identifying type of data transferred through this queue" type="string" is-not-null="yes"/>
- </class>
- 
-  <class name="DataMoveCallbackConf">
-  <attribute name="source_id" type="u32" init-value="0" is-not-null="yes"/>
-  <attribute name="data_type" description="Name of the output data type. Should be defined via a call to DUNE_DAQ_TYPESTRING" type="string" init-value="WIBEthFrame"/>
- </class>
-
- <class name="DataMoveCallbackDescriptor">
-  <attribute name="uid_base" description="Base for callback UID string. May be combined with a source id" type="string" is-not-null="yes"/>
-  <attribute name="data_type" description="string identifying type of data passed as a callback parameter" type="string" is-not-null="yes"/>
  </class>
 
  <class name="ReadoutApplication">


### PR DESCRIPTION
Added _ms suffix to wall-clock attributes of delayed postprocessing.

PS: These changes are meant for the next release. (Base branch will be changed to develop.)

[datahandlinglibs](https://github.com/DUNE-DAQ/datahandlinglibs/pull/132) dte/delayed_pp_monitoring
[appmodel](https://github.com/DUNE-DAQ/appmodel/pull/286) dte/delayedpp_attrs
[daqsystemtest](https://github.com/DUNE-DAQ/daqsystemtest/pull/311) dte/delayedpp_attrs
[snbmodules](https://github.com/DUNE-DAQ/snbmodules/pull/29) dte/delayedpp_attrs
[ehn1-daqconfigs](https://gitlab.cern.ch/dune-daq/online/ehn1-daqconfigs/-/merge_requests/279) dte/delayedpp_attrs