### PR TITLE
Change TPG threshold value type from u16 to s16.

### DIFF
--- a/schema/appmodel/trigger.schema.xml
+++ b/schema/appmodel/trigger.schema.xml
@@ -120,9 +120,9 @@
 
  <class name="AVXThresholdProcessor" description="TPG threshold signal processor. Filters the input signal by passing values that are above threshold and suppresing otherwise.">
   <superclass name="ProcessingStep"/>
-  <attribute name="plane0" description="Threshold for plane 0." type="u16" init-value="100" is-not-null="yes"/>
-  <attribute name="plane1" description="Threshold for plane 1." type="u16" init-value="100" is-not-null="yes"/>
-  <attribute name="plane2" description="Threshold for plane 2." type="u16" init-value="100" is-not-null="yes"/>
+  <attribute name="plane0" description="Threshold for plane 0." type="s16" init-value="100" is-not-null="yes"/>
+  <attribute name="plane1" description="Threshold for plane 1." type="s16" init-value="100" is-not-null="yes"/>
+  <attribute name="plane2" description="Threshold for plane 2." type="s16" init-value="100" is-not-null="yes"/>
  </class>
 
  <class name="DataSubscriberModule">

--- a/schema/appmodel/trigger.schema.xml
+++ b/schema/appmodel/trigger.schema.xml
@@ -118,7 +118,7 @@
   <attribute name="scale_divisor_plane2" description="Running sum scale divisor for plane 2." type="u8" init-value="1" is-not-null="yes"/>
  </class>
 
- <class name="AVXThresholdProcessor" description="TPG threshold signal processor. Filters the input signal by passing values that are above threshold and suppresing otherwise.">
+ <class name="AVXThresholdProcessor" description="TPG threshold signal processor. Filters the input signal by passing values that are above threshold and suppressing otherwise.">
   <superclass name="ProcessingStep"/>
   <attribute name="plane0" description="Threshold for plane 0." type="s16" init-value="100" is-not-null="yes"/>
   <attribute name="plane1" description="Threshold for plane 1." type="s16" init-value="100" is-not-null="yes"/>


### PR DESCRIPTION
# Description
The value type in configuration for TPG thresholds were incorrectly set to unsigned integer 16 instead of signed. The problem was notice at-scale with ProtoDUNE VD (NP02) when setting the permissible configuration maximum for `u16`. Manually setting the value to `s16` maximum behaved appropriately and as expected for TPG.

Configurations should generally not be using threshold values near the maximum, so it is not expected to break existing configurations.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

Check that trying to set a threshold value greater than `32767` is not permitted. There is otherwise no TPG or Readout functionality change. This is purely a first-level configuration change.

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

